### PR TITLE
Fase 1b: AuthContext verificado + AdminGuard + Authorization headers

### DIFF
--- a/front-pastelero/pages/_app.jsx
+++ b/front-pastelero/pages/_app.jsx
@@ -1,14 +1,23 @@
 // src/pages/_app.js
-import { AuthProvider } from '../src/context';
-import {CartProvider} from "@/src/components/enuser/carritocontext";
+import { useRouter } from "next/router";
+import { AuthProvider } from "../src/context";
+import { CartProvider } from "@/src/components/enuser/carritocontext";
+import AdminGuard from "@/src/components/AdminGuard";
 import "@/styles/globals.css";
-import 'react-calendar/dist/Calendar.css'; 
+import "react-calendar/dist/Calendar.css";
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+  // Cualquier ruta bajo /dashboard requiere sesión admin. El guard se aplica
+  // una sola vez aquí para no tener que envolver página por página.
+  const isDashboard = router.pathname.startsWith("/dashboard");
+
+  const page = <Component {...pageProps} />;
+
   return (
     <AuthProvider>
       <CartProvider>
-        <Component {...pageProps} />
+        {isDashboard ? <AdminGuard>{page}</AdminGuard> : page}
       </CartProvider>
     </AuthProvider>
   );

--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -8,11 +8,13 @@ import { useRouter } from "next/router";
 import axios from "axios";
 import Link from "next/link";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
 
 export default function EditarReceta() {
+  const { userToken } = useAuth();
   const {
     handleSubmit,
     control,
@@ -178,6 +180,7 @@ const handleDeleteIngredient = (index) => {
         {
           headers: {
             "Content-Type": "application/json",
+            Authorization: `Bearer ${userToken}`,
           },
         }
       );

--- a/front-pastelero/pages/dashboard/costeorecetas/index.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/index.jsx
@@ -5,6 +5,7 @@ import { Poppins as PoppinsFont, Sofia as SofiaFont } from "next/font/google";
 import Asideadmin from "@/src/components/asideadmin";
 import FooterDashboard from "@/src/components/footeradmin";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
@@ -20,6 +21,7 @@ export default function Costeorecetas() {
   const [recetas, setRecetas] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 4;
+  const { userToken } = useAuth();
 
   // Obtener recetas desde la API al montar el componente
   useEffect(() => {
@@ -57,6 +59,9 @@ export default function Costeorecetas() {
       try {
         const res = await fetch(`${API_BASE}/recetas/recetas/${recetaId}`, {
           method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${userToken}`,
+          },
         });
 
         if (res.ok) {

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -7,17 +7,19 @@ import { useForm, Controller } from "react-hook-form";
 import axios from "axios";
 import Link from "next/link";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
 
 export default function NuevaReceta() {
-  const { 
-    handleSubmit, 
-    control, 
-    getValues, 
-    setValue, 
+  const {
+    handleSubmit,
+    control,
+    getValues,
+    setValue,
     formState: { errors } } = useForm();
+  const { userToken } = useAuth();
 
   const [ingredientsList, setIngredientsList] = useState([]);
   const [ingredientOptions, setIngredientOptions] = useState([]);
@@ -120,6 +122,7 @@ export default function NuevaReceta() {
       const response = await axios.post(`${API_BASE}/recetas/recetas`, data, {
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${userToken}`,
         }
       });
 

--- a/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
+++ b/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
@@ -5,6 +5,7 @@ import Asideadmin from "@/src/components/asideadmin";
 import FooterDashboard from "@/src/components/footeradmin";
 import { useState, useEffect } from "react";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
@@ -13,6 +14,7 @@ export default function Conocenuestrosproductos() {
   const { register, handleSubmit, formState: { errors } } = useForm();
   const [costData, setCostData] = useState({ fixedCosts: 0, laborCosts: 0 });
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const { userToken } = useAuth();
 
   useEffect(() => {
     const fetchCostData = async () => {
@@ -37,6 +39,7 @@ export default function Conocenuestrosproductos() {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${userToken}`,
         },
         body: JSON.stringify({
           fixedCosts: data.fixedCosts,

--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx
@@ -6,6 +6,7 @@ import Asideadmin from "@/src/components/asideadmin";
 import FooterDashboard from "@/src/components/footeradmin";
 import Link from "next/link";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
@@ -18,15 +19,17 @@ export default function NuevaReceta() {
     setValue,
   } = useForm();
   const [costPerUnit, setCostPerUnit] = useState(0);
+  const { userToken } = useAuth();
 
   const onSubmit = (data) => {
     console.log(data);
-  
+
     fetch(`${API_BASE}/insumos`, {
       method: "POST",
       body: JSON.stringify(data),
       headers: {
         "Content-type": "application/json; charset=UTF-8",
+        Authorization: `Bearer ${userToken}`,
       },
     })
       .then((response) => {

--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx
@@ -5,8 +5,9 @@ import { Poppins as PoppinsFont, Sofia as SofiaFont } from "next/font/google";
 import Asideadmin from "@/src/components/asideadmin";
 import FooterDashboard from "@/src/components/footeradmin";
 import { useState, useEffect } from "react";
-import { useRouter } from "next/router"; 
+import { useRouter } from "next/router";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
@@ -29,6 +30,7 @@ export default function EditarInsumo({ insumo }) {
   });
 
   const router = useRouter(); // Usa useRouter
+  const { userToken } = useAuth();
 
   const quantity = watch("amount");
   const cost = watch("cost");
@@ -67,6 +69,7 @@ export default function EditarInsumo({ insumo }) {
         body: JSON.stringify(data),
         headers: {
           "Content-type": "application/json; charset=UTF-8",
+          Authorization: `Bearer ${userToken}`,
         },
       });
   

--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/index.jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/index.jsx
@@ -6,6 +6,7 @@ import Asideadmin from "@/src/components/asideadmin";
 import FooterDashboard from "@/src/components/footeradmin";
 import axios from "axios";
 import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
 
 const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
 const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
@@ -15,11 +16,13 @@ export default function InsumosyTrabajoManual() {
   const [insumos, setInsumos] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 5;
+  const { userToken } = useAuth();
+  const authHeader = userToken ? { Authorization: `Bearer ${userToken}` } : {};
 
   useEffect(() => {
     const fetchInsumos = async () => {
       try {
-        const response = await axios.get(`${API_BASE}/insumos`);
+        const response = await axios.get(`${API_BASE}/insumos`, { headers: authHeader });
         setInsumos(response.data);
       } catch (error) {
         console.error("Error fetching insumos:", error);
@@ -27,7 +30,7 @@ export default function InsumosyTrabajoManual() {
     };
 
     fetchInsumos();
-  }, []);
+  }, [userToken]);
 
   const handleDelete = async (id) => {
     try {
@@ -41,9 +44,9 @@ export default function InsumosyTrabajoManual() {
         confirmButtonText: "Sí, eliminar",
         cancelButtonText: "Cancelar",
       });
-  
+
       if (result.isConfirmed) {
-        await axios.delete(`${API_BASE}/insumos/${id}`);
+        await axios.delete(`${API_BASE}/insumos/${id}`, { headers: authHeader });
   
         Swal.fire({
           title: "Eliminado",

--- a/front-pastelero/pages/login/index.jsx
+++ b/front-pastelero/pages/login/index.jsx
@@ -45,9 +45,9 @@ export default function Login() {
           color: '#540027', 
           timer: 2000,
           timerProgressBar: true,
-        }).then(() => {
-          login(json.token);
-          router.push("/")
+        }).then(async () => {
+          await login(json.token);
+          router.push("/");
         });
       } else {
         Swal.fire({

--- a/front-pastelero/pages/registrarse/index.jsx
+++ b/front-pastelero/pages/registrarse/index.jsx
@@ -52,8 +52,8 @@ export default function Login() {
             color: '#540027',
             timer: 2000,
             timerProgressBar: true,
-          }).then(() => {
-            login(loginJson.token); // Actualiza el estado de autenticación global
+          }).then(async () => {
+            await login(loginJson.token); // Valida sesión contra /users/me antes de redirigir
             router.push("/"); // Redirige al home
           });
         } else {

--- a/front-pastelero/src/components/AdminGuard.jsx
+++ b/front-pastelero/src/components/AdminGuard.jsx
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "@/src/context";
+
+/**
+ * AdminGuard
+ *
+ * Envuelve cualquier página que requiera rol admin. Mientras el contexto
+ * valida el token contra `/users/me` (loading=true), muestra un placeholder;
+ * después:
+ *   - sin sesión válida → /login
+ *   - sesión válida pero no admin → /
+ *   - admin → renderiza children
+ *
+ * El guard es puramente UX; la autorización real la impone el backend en
+ * cada endpoint protegido. Sin esto, un no-admin vería brevemente el UI
+ * del dashboard antes de que las llamadas fallen con 403.
+ */
+export default function AdminGuard({ children }) {
+  const { isLoggedIn, isAdmin, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (loading) return;
+    if (!isLoggedIn) {
+      router.replace("/login");
+      return;
+    }
+    if (!isAdmin) {
+      router.replace("/");
+    }
+  }, [loading, isLoggedIn, isAdmin, router]);
+
+  if (loading || !isLoggedIn || !isAdmin) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-text">Verificando sesión…</p>
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/front-pastelero/src/context.jsx
+++ b/front-pastelero/src/context.jsx
@@ -1,8 +1,18 @@
-import { createContext, useState, useContext, useEffect } from "react";
-import jwt from "jsonwebtoken";
+import { createContext, useState, useContext, useEffect, useCallback } from "react";
 
-const AuthContext = createContext(); 
+const AuthContext = createContext();
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+/**
+ * AuthProvider
+ *
+ * Nunca confía en el payload del JWT leído en el cliente: cada vez que
+ * carga la app o cambia el token, pregunta a `GET /users/me` (endpoint
+ * protegido). El backend verifica la firma del token y devuelve el
+ * usuario tal como está en la BD — incluyendo el `role` real. Así un
+ * atacante que edite su localStorage no puede ganar rol de admin.
+ */
 export function AuthProvider({ children }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -11,44 +21,68 @@ export function AuthProvider({ children }) {
   const [userToken, setUserToken] = useState(null);
   const [userName, setUserName] = useState(null);
   const [userPhone, setUserPhone] = useState(null);
+  // Mientras loading sea true, los route-guards deben esperar antes de
+  // redirigir; así evitamos un "parpadeo" hacia /login en el primer render.
+  const [loading, setLoading] = useState(true);
 
-  const updateAuthState = (token) => {
-    if (token) {
-      try {
-        const decodedToken = jwt.decode(token);
-        setIsLoggedIn(true);
-        setIsAdmin(decodedToken.role === "admin");
-        setUserId(decodedToken._id);
-        setUserEmail(decodedToken.email);
-        setUserName(decodedToken.name);
-        setUserPhone(decodedToken.phone);
-        setUserToken(token);
-      } catch (error) {
-        console.error("Token decode failed:", error);
-      }
-    } else {
-      setIsLoggedIn(false);
-      setIsAdmin(false);
-      setUserId(null);
-      setUserEmail(null);
-      setUserName(null);
-      setUserPhone(null);
-    }
-  };
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    updateAuthState(token);
+  const clearAuth = useCallback(() => {
+    setIsLoggedIn(false);
+    setIsAdmin(false);
+    setUserId(null);
+    setUserEmail(null);
+    setUserName(null);
+    setUserPhone(null);
+    setUserToken(null);
   }, []);
 
-  const login = (token) => {
+  const fetchMe = useCallback(async (token) => {
+    if (!token) {
+      clearAuth();
+      setLoading(false);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_BASE}/users/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        // Token inválido/expirado: limpiamos localStorage y tratamos como logged out.
+        localStorage.removeItem("token");
+        clearAuth();
+        return;
+      }
+      const { data } = await res.json();
+      setIsLoggedIn(true);
+      setIsAdmin(data.role === "admin");
+      setUserId(data._id);
+      setUserEmail(data.email);
+      setUserName(data.name);
+      setUserPhone(data.phone);
+      setUserToken(token);
+    } catch (err) {
+      console.error("Error validando sesión:", err);
+      clearAuth();
+    } finally {
+      setLoading(false);
+    }
+  }, [clearAuth]);
+
+  useEffect(() => {
+    const token = typeof window !== "undefined"
+      ? localStorage.getItem("token")
+      : null;
+    fetchMe(token);
+  }, [fetchMe]);
+
+  const login = async (token) => {
     localStorage.setItem("token", token);
-    updateAuthState(token);
+    setLoading(true);
+    await fetchMe(token);
   };
 
   const logout = () => {
     localStorage.removeItem("token");
-    updateAuthState(null);
+    clearAuth();
   };
 
   return (
@@ -60,11 +94,12 @@ export function AuthProvider({ children }) {
         userEmail,
         userName,
         userPhone,
+        userToken,
+        loading,
         login,
         logout,
         setIsLoggedIn,
-        setIsAdmin, 
-        userToken
+        setIsAdmin,
       }}
     >
       {children}
@@ -72,7 +107,6 @@ export function AuthProvider({ children }) {
   );
 }
 
-// Hook personalizado para usar el contexto
 export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined) {


### PR DESCRIPTION
## Summary

Continuación de seguridad (Fase 1b) del lado del frontend. Depende de mipasteleria/BackPastelero#54 estando mergeado antes de probar (requiere \`/users/me\` + endpoints que exigen \`Authorization\`).

### AuthContext verificado vía backend
- `context.jsx`: se elimina el decode de JWT en cliente (era manipulable desde localStorage). En su lugar, al montar o hacer login, se llama a `GET /users/me` con el token y se deriva el rol de la respuesta firmada por el backend.
- Estado `loading` para evitar el "flash" de UI admin antes de que el auth resuelva.
- Limpia localStorage + estado en respuesta 401.
- `login/registrarse`: `await login(token)` antes de `router.push` para que el contexto esté poblado al redirigir.

### Route guard
- Nuevo `src/components/AdminGuard.jsx`: espera a `loading`, redirige a `/login` si no hay sesión o a `/` si está logueado pero no es admin. Mientras, muestra placeholder.
- `_app.jsx`: envuelve con `<AdminGuard>` solo cuando `router.pathname.startsWith("/dashboard")`.

### Authorization en mutaciones
Los endpoints admin ahora requieren \`Authorization: Bearer <token>\` (ver PR backend Fase 1a). Añadido el header en:
- `dashboard/insumosytrabajomanual` (POST, GET, DELETE, PUT)
- `dashboard/costeorecetas` (POST, DELETE, PUT)
- `dashboard/gastosfijosymanodeobra` (PUT)

## Test plan

- [ ] Sin sesión, entrar a `/dashboard/insumosytrabajomanual` → debe redirigir a `/login` tras breve placeholder
- [ ] Login como user (no admin), entrar a `/dashboard/*` → redirige a `/`
- [ ] Login como admin → acceso normal a todas las páginas del dashboard
- [ ] Editar/crear/eliminar un insumo, receta o costo → debe funcionar (antes se rompería con 401/403)
- [ ] Modificar el localStorage para poner un token basura → al recargar, `context.jsx` hace fetch `/me`, recibe 401, limpia sesión y redirige