### PR TITLE
Fase 2 frontend — costeo de recetas sin doble conteo + insumoId

### DIFF
--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -115,24 +115,33 @@ export default function EditarReceta() {
   }, [calculateTotal]);
 
 const handleAddIngredient = () => {
-  const { ingrediente, cantidad, precio, unidad } = getValues();
-  if (ingrediente.trim() && cantidad && precio) {
-    const total = (parseFloat(precio) || 0) / (parseFloat(cantidad) || 1);
-    const newIngredient = { ingrediente, cantidad, precio: parseFloat(precio), unidad, total: total.toFixed(2) };
+  const { ingrediente, unidad } = getValues();
+  const cantidadRaw = parseFloat(getValues("cantidad") || 0);
+  if (!ingrediente?.trim() || !cantidadRaw) return;
 
-    console.log("Form Data on Add:", getValues());
-    console.log("Ingredient to be Added:", newIngredient);
-
-    setIngredientsList(prevIngredients => {
-      const newIngredients = [...prevIngredients, newIngredient];
-      calculateTotal();
-      return newIngredients;
-    });
-    setValue("cantidad", "");
-    setSelectedIngredient(null);
+  let precio, total;
+  if (selectedIngredient?.cost && selectedIngredient?.amount) {
+    const unitCost = selectedIngredient.cost / selectedIngredient.amount;
+    precio = Math.round(unitCost * cantidadRaw * 100) / 100;
+    total  = Math.round(unitCost * 100) / 100;
   } else {
-    console.error("Faltan valores para agregar el ingrediente");
+    precio = parseFloat(getValues("precio") || 0);
+    total  = cantidadRaw ? Math.round((precio / cantidadRaw) * 100) / 100 : 0;
   }
+
+  const newIngredient = {
+    insumoId: selectedIngredient?._id || null,
+    ingrediente,
+    cantidad: cantidadRaw,
+    precio,
+    unidad,
+    total,
+  };
+
+  setIngredientsList(prev => [...prev, newIngredient]);
+  setValue("cantidad", "");
+  setValue("precio", "");
+  setSelectedIngredient(null);
 };
 
 const handleDeleteIngredient = (index) => {
@@ -267,17 +276,14 @@ const handleDeleteIngredient = (index) => {
                           {...field}
                           onChange={(e) => {
                             field.onChange(e);
-                            setSelectedIngredient(e.target.value);
-                            const selectedIngredientData = ingredientOptions.find(option => option.name === e.target.value);
-                            if (selectedIngredientData) {
-                              setValue("precio", selectedIngredientData.cost);
-                              setValue("unidad", selectedIngredientData.unit);
-                            }
+                            const found = ingredientOptions.find(o => o.name === e.target.value);
+                            setSelectedIngredient(found || null);
+                            if (found) setValue("unidad", found.unit);
                           }}
                         >
                           <option value="">Selecciona un ingrediente</option>
                           {ingredientOptions.map(option => (
-                            <option key={option._id} value={option.name}>{option.name}</option>
+                            <option key={option._id} value={option.name}>{option.name} — ${option.cost}/{option.amount}{option.unit}</option>
                           ))}
                         </select>
                       )}

--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -59,15 +59,9 @@ export default function EditarReceta() {
         const additionalCostsValue = parseFloat(getValues("additional_costs") || 0);
         const profitMarginValue = parseFloat(getValues("profit_margin") || 0);
     
-        const totalCost =
-          ingredientTotal + data.fixedCosts + data.laborCosts + additionalCostsValue;
-    
-        const initialTotal =
-          totalCost +
-          (totalCost * profitMarginValue) / 100 +
-          (totalCost * specialTaxValue) / 100;
-    
-        setTotal(initialTotal);
+        // No incluir overhead ni margen en total_cost; eso lo hace costeoHandler
+        const rawCost = ingredientTotal + additionalCostsValue;
+        setTotal(rawCost + (rawCost * specialTaxValue) / 100);
       } catch (error) {
         console.error("Error fetching costs:", error);
       }
@@ -109,28 +103,12 @@ export default function EditarReceta() {
 
   const calculateTotal = useCallback(() => {
     const ingredientTotal = ingredientsList.reduce((acc, ingredient) => acc + parseFloat(ingredient.precio || 0), 0);
-    const { 
-      special_tax, 
-      additional_costs, 
-      profit_margin 
-    } = getValues();
-  
+    const { special_tax, additional_costs } = getValues();
     const specialTaxValue = parseFloat(special_tax || 0);
     const additionalCostsValue = parseFloat(additional_costs || 0);
-    const profitMarginValue = parseFloat(profit_margin || 0);
-    const totalCost = 
-    ingredientTotal + 
-    fixedCosts + 
-    fixedCostsHours + 
-    additionalCostsValue;
-  
-    const totalWithProfit = 
-    totalCost + 
-    (totalCost * profitMarginValue / 100) + 
-    (totalCost * specialTaxValue / 100);
-  
-    setTotal(totalWithProfit);
-  }, [ingredientsList, getValues, fixedCosts, fixedCostsHours]);
+    const rawCost = ingredientTotal + additionalCostsValue;
+    setTotal(rawCost + (rawCost * specialTaxValue / 100));
+  }, [ingredientsList, getValues]);
 
   useEffect(() => {
     calculateTotal();
@@ -452,10 +430,13 @@ const handleDeleteIngredient = (index) => {
                 htmlFor="total_cost"
                 className={`text-3xl p-2 font-bold mb-4 ${sofia.className}`}
               >
-                Costo total estimado
+                Costo por lote de ingredientes
               </label>
               <p id="total_cost" className="text-center text-2xl">
                 {total !== null ? total.toFixed(2) : "0.00"} MXN
+              </p>
+              <p className="text-center text-xs text-gray-400 mt-1">
+                Solo ingredientes + costos adicionales + IEPS. El overhead y el margen se calculan en el costeo de cotización.
               </p>
             </div>
             <div className="flex flex-col md:flex-row gap-10 justify-center">

--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -44,7 +44,7 @@ export default function EditarReceta() {
   
     const fetchCosts = async () => {
       try {
-        const response = await axios.get(`${API_BASE}/costs/66dc00a6b33d98dd9e2b91a9`);
+        const response = await axios.get(`${API_BASE}/costs`);
         const data = response.data;
         setFixedCosts(data.fixedCosts);
         setFixedCostsHours(data.laborCosts);

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -69,21 +69,35 @@ export default function NuevaReceta() {
   }, [calculateTotal]);
   
   const handleAddIngredient = () => {
-    const { ingrediente, cantidad, precio, unidad } = getValues();
-    if (ingrediente.trim() && cantidad && precio) {
-      const total = (parseFloat(precio) || 0) / (parseFloat(cantidad) || 1);
-      const newIngredient = { ingrediente, cantidad, precio: parseFloat(precio), unidad, total: total.toFixed(2) };
+    const { ingrediente, unidad } = getValues();
+    const cantidadRaw = parseFloat(getValues("cantidad") || 0);
+    if (!ingrediente?.trim() || !cantidadRaw) return;
 
-      setIngredientsList(prevIngredients => {
-        const newIngredients = [...prevIngredients, newIngredient];
-        calculateTotal();
-        return newIngredients;
-      });
-      setValue("cantidad", "");
-      setSelectedIngredient(null);
+    let precio, total;
+    if (selectedIngredient?.cost && selectedIngredient?.amount) {
+      // Costo proporcional: (precio_paquete / cantidad_paquete) × cantidad_usada
+      const unitCost = selectedIngredient.cost / selectedIngredient.amount;
+      precio = Math.round(unitCost * cantidadRaw * 100) / 100;
+      total  = Math.round(unitCost * 100) / 100;
     } else {
-      console.error("Faltan valores para agregar el ingrediente");
+      // Entrada manual sin insumo seleccionado del catálogo
+      precio = parseFloat(getValues("precio") || 0);
+      total  = cantidadRaw ? Math.round((precio / cantidadRaw) * 100) / 100 : 0;
     }
+
+    const newIngredient = {
+      insumoId: selectedIngredient?._id || null,
+      ingrediente,
+      cantidad: cantidadRaw,
+      precio,
+      unidad,
+      total,
+    };
+
+    setIngredientsList(prev => [...prev, newIngredient]);
+    setValue("cantidad", "");
+    setValue("precio", "");
+    setSelectedIngredient(null);
   };
 
   const handleDeleteIngredient = (index) => {
@@ -231,17 +245,14 @@ export default function NuevaReceta() {
                           {...field}
                           onChange={(e) => {
                             field.onChange(e);
-                            setSelectedIngredient(e.target.value);
-                            const selectedIngredientData = ingredientOptions.find(option => option.name === e.target.value);
-                            if (selectedIngredientData) {
-                              setValue("precio", selectedIngredientData.cost);
-                              setValue("unidad", selectedIngredientData.unit);
-                            }
+                            const found = ingredientOptions.find(o => o.name === e.target.value);
+                            setSelectedIngredient(found || null);
+                            if (found) setValue("unidad", found.unit);
                           }}
                         >
                           <option value="">Selecciona un ingrediente</option>
                           {ingredientOptions.map(option => (
-                            <option key={option._id} value={option.name}>{option.name}</option>
+                            <option key={option._id} value={option.name}>{option.name} — ${option.cost}/{option.amount}{option.unit}</option>
                           ))}
                         </select>
                       )}

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -45,8 +45,6 @@ export default function NuevaReceta() {
       const data = response.data;
       setFixedCosts(data.fixedCosts);
       setFixedCostsHours(data.laborCosts);
-      const initialTotal = data.fixedCosts + data.laborCosts;
-      setTotal(initialTotal);
       } catch (error) {
         console.error("Error fetching costs:", error);
       }
@@ -58,27 +56,13 @@ export default function NuevaReceta() {
 
   const calculateTotal = useCallback(() => {
     const ingredientTotal = ingredientsList.reduce((acc, ingredient) => acc + parseFloat(ingredient.precio || 0), 0);
-    const { 
-      special_tax, 
-      additional_costs, 
-      profit_margin 
-    } = getValues();
-  
+    const { special_tax, additional_costs } = getValues();
     const specialTaxValue = parseFloat(special_tax || 0);
     const additionalCostsValue = parseFloat(additional_costs || 0);
-    const profitMarginValue = parseFloat(profit_margin || 0);
-    const totalCost = 
-    ingredientTotal + 
-    fixedCosts + 
-    fixedCostsHours + 
-    additionalCostsValue;
-  
-    const totalWithProfit = totalCost + 
-    (totalCost * profitMarginValue / 100) + 
-    (totalCost * specialTaxValue / 100);
-  
-    setTotal(totalWithProfit);
-  }, [ingredientsList, getValues, fixedCosts, fixedCostsHours]);
+    // Solo costo puro de materiales + IEPS; el overhead y el margen los aplica costeoHandler
+    const rawCost = ingredientTotal + additionalCostsValue;
+    setTotal(rawCost + (rawCost * specialTaxValue / 100));
+  }, [ingredientsList, getValues]);
 
   useEffect(() => {
     calculateTotal();
@@ -399,13 +383,13 @@ export default function NuevaReceta() {
             </div>
             <div 
             className="my-10 p-4 rounded-xl bg-rose-50">
-              <h2 
+              <h2
               className={`text-3xl p-2 font-bold mb-4 ${sofia.className}`}>
-                Costo total estimado
+                Costo por lote de ingredientes
               </h2>
-              <p 
-              className="text-center text-2xl">
-                {total.toFixed(2)} MXN
+              <p className="text-center text-2xl">{total.toFixed(2)} MXN</p>
+              <p className="text-center text-xs text-gray-400 mt-1">
+                Solo ingredientes + costos adicionales + IEPS. El overhead y el margen se calculan en el costeo de cotización.
               </p>
             </div>
             <div className="flex flex-col md:flex-row gap-10 justify-center">

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -41,7 +41,7 @@ export default function NuevaReceta() {
 
   const fetchCosts = async () => {
     try {
-      const response = await axios.get(`${API_BASE}/costs/66dc00a6b33d98dd9e2b91a9`);
+      const response = await axios.get(`${API_BASE}/costs`);
       const data = response.data;
       setFixedCosts(data.fixedCosts);
       setFixedCostsHours(data.laborCosts);

--- a/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
+++ b/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
@@ -19,7 +19,7 @@ export default function Conocenuestrosproductos() {
   useEffect(() => {
     const fetchCostData = async () => {
       try {
-        const response = await fetch(`${API_BASE}/costs/66dc00a6b33d98dd9e2b91a9`);
+        const response = await fetch(`${API_BASE}/costs`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
@@ -35,7 +35,7 @@ export default function Conocenuestrosproductos() {
 
   const onSubmit = async (data) => {
     try {
-      const response = await fetch(`${API_BASE}/costs/66dc00a6b33d98dd9e2b91a9`, {
+      const response = await fetch(`${API_BASE}/costs`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Cambios

- `gastosfijosymanodeobra`, `nuevareceta`, `editarreceta`: remueve ID hardcodeado `66dc00a6b33d98dd9e2b91a9`, usa `GET/PUT /costs`
- `nuevareceta` y `editarreceta`: `total_cost` ya no incluye overhead ni margen — solo ingredientes + additional + IEPS. Evita el doble conteo con `costeoHandler`
- `handleAddIngredient` calcula precio proporcional `(cost/amount) × cantidad` en vez del precio del paquete completo, y guarda `insumoId` para que el backend propague cambios de precio automáticamente
- Dropdown de ingredientes muestra precio unitario del insumo como referencia

🤖 Generated with [Claude Code](https://claude.ai/claude-code)