### PR TITLE
fix: cambiar CDMX por Guadalajara en textos del sitio

### DIFF
--- a/front-pastelero/pages/cursos.jsx
+++ b/front-pastelero/pages/cursos.jsx
@@ -62,7 +62,7 @@ export default function Cursos() {
                 Cursos para soñadores <span style={{ color: "var(--rosa)" }}>y reposteros.</span>
               </h1>
               <p style={{ fontSize: "1.05rem", color: "var(--text-soft)", lineHeight: 1.7, marginBottom: "1.5rem", maxWidth: "50ch" }}>
-                Clases en grupos pequeños, en nuestro estudio en CDMX. Te llevas tu pieza a casa, recetas paso a paso y un mandil bordado.
+                Clases en grupos pequeños, en nuestro estudio en Guadalajara. Te llevas tu pieza a casa, recetas paso a paso y un mandil bordado.
               </p>
               {/* Stats */}
               <div style={{ display: "flex", gap: "2.5rem" }}>

--- a/front-pastelero/pages/enduser/carrito.jsx
+++ b/front-pastelero/pages/enduser/carrito.jsx
@@ -261,7 +261,7 @@ export default function Carrito() {
 
               {/* Trust badges */}
               <div style={{ marginTop: "0.75rem", display: "flex", gap: "0.5rem", justifyContent: "center", flexWrap: "wrap" }}>
-                {["🔒 Pago seguro", "📦 Entrega CDMX", "⭐ 4.9/5"].map(b => (
+                {["🔒 Pago seguro", "📦 Entrega Guadalajara", "⭐ 4.9/5"].map(b => (
                   <span key={b} style={{ fontSize: "0.7rem", fontWeight: 700, color: "var(--text-muted)", background: "var(--bg-raised)", padding: "4px 10px", borderRadius: "var(--r-pill)", border: "1px solid var(--border-color)" }}>{b}</span>
                 ))}
               </div>

--- a/front-pastelero/pages/linktree.jsx
+++ b/front-pastelero/pages/linktree.jsx
@@ -113,7 +113,7 @@ export default function Linktree() {
 
         {/* Brand name */}
         <h1 className={sofia.className} style={{ fontSize: "3.5rem", color: "var(--rosa-2)", lineHeight: 1, marginBottom: "0.5rem" }}>El Ruiseñor</h1>
-        <p style={{ fontFamily: "var(--font-nunito)", fontWeight: 700, fontSize: "1.05rem", marginBottom: "0.5rem" }}>Pastelería artesanal · CDMX</p>
+        <p style={{ fontFamily: "var(--font-nunito)", fontWeight: 700, fontSize: "1.05rem", marginBottom: "0.5rem" }}>Pastelería artesanal · Guadalajara</p>
         <p style={{ color: "#FFD8DF", fontSize: "0.875rem", margin: "0.75rem auto 1.5rem", maxWidth: "33ch", lineHeight: 1.7 }}>
           Hornea recuerdos dulces. Pasteles vintage, galletas NY, cursos y eventos. Reservas con 72h de anticipación.
         </p>
@@ -177,7 +177,7 @@ export default function Linktree() {
 
         {/* Footer */}
         <p style={{ marginTop: "2.5rem", color: "rgba(255,216,223,.65)", fontSize: "0.7rem" }}>
-          © 2026 El Ruiseñor · Hecho con cariño en CDMX
+          © 2026 El Ruiseñor · Hecho con cariño en Guadalajara
         </p>
       </div>
     </div>

--- a/front-pastelero/src/components/navbar.jsx
+++ b/front-pastelero/src/components/navbar.jsx
@@ -651,7 +651,7 @@ const NavbarAdmin = () => {
                 fontFamily: "var(--font-nunito)",
               }}
             >
-              Pastelería El Ruiseñor · CDMX
+              Pastelería El Ruiseñor · Guadalajara
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

La pastelería opera en **Guadalajara, Jalisco** — no en CDMX. Se corrigen los 5 textos visibles que decían \"CDMX\".

## Cambios

| Archivo | Línea | Texto |
|---|---|---|
| \`pages/linktree.jsx\` | 116 | \"Pastelería artesanal · CDMX\" → \"…· Guadalajara\" |
| \`pages/linktree.jsx\` | 180 | footer \"Hecho con cariño en CDMX\" → \"…en Guadalajara\" |
| \`pages/cursos.jsx\` | 65 | \"nuestro estudio en CDMX\" → \"…en Guadalajara\" |
| \`pages/enduser/carrito.jsx\` | 264 | badge \"📦 Entrega CDMX\" → \"…Entrega Guadalajara\" |
| \`src/components/navbar.jsx\` | 654 | \"El Ruiseñor · CDMX\" → \"…· Guadalajara\" |

## Test plan

- [ ] Abrir https://[preview]/linktree y verificar que el subtítulo y el footer dicen \"Guadalajara\"
- [ ] Abrir /cursos y verificar el párrafo de intro
- [ ] Abrir /enduser/carrito y verificar el badge de entrega
- [ ] Abrir el dashboard admin y verificar el texto del navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)