### PR TITLE
feat(galletas): UI de precio sugerido desde receta + alerta margen bajo

### DIFF
--- a/front-pastelero/pages/dashboard/galletas-ny/index.jsx
+++ b/front-pastelero/pages/dashboard/galletas-ny/index.jsx
@@ -27,6 +27,7 @@ const NEW_FLAVOR = {
   esTemporada: false,
   activo: true,
   orden: 0,
+  recetaId: "",
 };
 
 /* Predefined gradient swatches for quick pick */
@@ -103,21 +104,27 @@ export default function GalletasAdminPage() {
   const authHeader = userToken ? { Authorization: `Bearer ${userToken}` } : {};
 
   const [sabores, setSabores]       = useState([]);
+  const [recetas, setRecetas]       = useState([]);  // catálogo de recetas para el dropdown
   const [loading, setLoading]       = useState(true);
   const [showForm, setShowForm]     = useState(false);
   const [editing, setEditing]       = useState(null); // sabor being edited
   const [formData, setFormData]     = useState(NEW_FLAVOR);
+  const [costeoData, setCosteoData] = useState(null); // breakdown del cálculo de precio
+  const [costeoBusy, setCosteoBusy] = useState(false);
   const [stockDelta, setStockDelta] = useState({});   // saborId -> "+25" or "-3"
   const [uploadBusy, setUploadBusy] = useState(false);
   const [imagenesRotas, setImagenesRotas] = useState({});
   const markImageBroken = (id) =>
     setImagenesRotas((prev) => (prev[id] ? prev : { ...prev, [id]: true }));
 
-  /* ── Load all flavors (including inactive) ── */
+  /* ── Load all flavors (including inactive) with margin watch ──
+   * `conMargen=true` hace que el back enriquezca cada sabor con
+   * `costoLive`, `margenActual`, `alertaMargenBajo` — para el badge
+   * de "margen bajo" en el listado. */
   const loadSabores = async () => {
     setLoading(true);
     try {
-      const res = await axios.get(`${API_BASE}/galletaSabores?todos=true`, { headers: authHeader });
+      const res = await axios.get(`${API_BASE}/galletaSabores?todos=true&conMargen=true`, { headers: authHeader });
       setSabores(res.data.data || []);
     } catch (err) {
       console.error(err);
@@ -127,15 +134,64 @@ export default function GalletasAdminPage() {
     }
   };
 
+  /* ── Load recetas para el dropdown del form ── */
+  const loadRecetas = async () => {
+    try {
+      const res = await axios.get(`${API_BASE}/recetas`, { headers: authHeader });
+      // Solo necesitamos las que tienen porciones para poder costear
+      const list = (res.data?.data || []).filter(r => r.portions > 0 && typeof r.total_cost === "number");
+      setRecetas(list);
+    } catch (err) {
+      console.error("No se pudieron cargar las recetas:", err);
+      // Silencioso — la feature de costeo desde receta es opcional, el admin
+      // puede seguir capturando precio manual.
+    }
+  };
+
   useEffect(() => {
-    if (userToken) loadSabores();
+    if (userToken) {
+      loadSabores();
+      loadRecetas();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userToken]);
+
+  /* ── Calcular precio sugerido desde receta ──
+   * Llama al back con el recetaId; si responde con breakdown, lo
+   * guardamos en state y autopoblamos `precio` con el sugerido (el
+   * admin lo puede ajustar antes de guardar). */
+  const calcularPrecioDesdeReceta = async (recetaId) => {
+    if (!recetaId) { setCosteoData(null); return; }
+    setCosteoBusy(true);
+    try {
+      const res = await axios.post(
+        `${API_BASE}/galletaSabores/calcular-precio`,
+        { recetaId },
+        { headers: authHeader }
+      );
+      const data = res.data?.data;
+      if (data) {
+        setCosteoData(data);
+        // Autopoblar precio solo si está en el default (35) o vacío —
+        // si el admin ya editó manualmente, no lo pisamos.
+        setFormData((prev) => ({
+          ...prev,
+          precio: (prev.precio === 35 || !prev.precio) ? data.precioSugerido : prev.precio,
+        }));
+      }
+    } catch (err) {
+      const msg = err.response?.data?.message || err.message || "No se pudo calcular el precio";
+      Swal.fire({ icon: "warning", title: "Error al calcular", text: msg });
+    } finally {
+      setCosteoBusy(false);
+    }
+  };
 
   /* ── Open form for create ── */
   const openCreate = () => {
     setEditing(null);
     setFormData(NEW_FLAVOR);
+    setCosteoData(null);
     setShowForm(true);
   };
 
@@ -157,8 +213,31 @@ export default function GalletasAdminPage() {
       esTemporada: !!s.esTemporada,
       activo:      s.activo !== false,
       orden:       s.orden || 0,
+      recetaId:    s.recetaId || "",
     });
+    setCosteoData(null);
     setShowForm(true);
+  };
+
+  /* ── Recostear: refresca el snapshot al costo actual de la receta ── */
+  const handleRecostear = async (sabor) => {
+    const result = await Swal.fire({
+      title: "¿Recostear este sabor?",
+      html: `Se actualizará el costo unitario al valor actual de la receta. <b>El precio mostrado al cliente NO cambia</b> — solo se refresca el snapshot interno.`,
+      icon: "info",
+      showCancelButton: true,
+      confirmButtonText: "Sí, recostear",
+      cancelButtonText: "Cancelar",
+      background: "#fff1f2", color: "#540027",
+    });
+    if (!result.isConfirmed) return;
+    try {
+      await axios.post(`${API_BASE}/galletaSabores/${sabor._id}/recostear`, {}, { headers: authHeader });
+      Swal.fire({ icon: "success", title: "Costo actualizado", timer: 1500, showConfirmButton: false, background: "#fff1f2", color: "#540027" });
+      loadSabores();
+    } catch (err) {
+      Swal.fire({ icon: "error", title: "Error", text: err.response?.data?.message || err.message });
+    }
   };
 
   /* ── Image upload to GCS via /upload ──
@@ -200,10 +279,12 @@ export default function GalletasAdminPage() {
   const handleSave = async (e) => {
     e?.preventDefault();
     try {
+      // Normaliza recetaId: el back espera ObjectId o null (no string vacío)
+      const payload = { ...formData, recetaId: formData.recetaId || null };
       if (editing) {
-        await axios.put(`${API_BASE}/galletaSabores/${editing._id}`, formData, { headers: authHeader });
+        await axios.put(`${API_BASE}/galletaSabores/${editing._id}`, payload, { headers: authHeader });
       } else {
-        await axios.post(`${API_BASE}/galletaSabores`, formData, { headers: authHeader });
+        await axios.post(`${API_BASE}/galletaSabores`, payload, { headers: authHeader });
       }
       Swal.fire({
         icon: "success",
@@ -336,13 +417,16 @@ export default function GalletasAdminPage() {
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(320px,1fr))", gap: "1rem" }}>
               {sabores.map((s) => {
                 const badge = stockBadge(s.stock);
+                // Resaltado cuando el costo "live" (insumos + branding actual)
+                // dejó al sabor con margen menor al mínimo configurado.
+                const enAlerta = s.alertaMargenBajo === true;
                 return (
                   <div key={s._id} style={{
-                    background: "var(--bg-raised)",
+                    background: enAlerta ? "linear-gradient(180deg,#fff5e6,var(--bg-raised))" : "var(--bg-raised)",
                     borderRadius: "var(--r-xl)",
                     padding: "1.25rem",
-                    boxShadow: "var(--shadow-sm)",
-                    border: !s.activo ? "2px dashed var(--border-strong)" : "2px solid transparent",
+                    boxShadow: enAlerta ? "0 0 0 3px #FF9A56, var(--shadow-sm)" : "var(--shadow-sm)",
+                    border: !s.activo ? "2px dashed var(--border-strong)" : enAlerta ? "2px solid #FF6F00" : "2px solid transparent",
                     opacity: s.activo ? 1 : 0.6,
                   }}>
                     {/* Top row */}
@@ -363,12 +447,37 @@ export default function GalletasAdminPage() {
                         <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
                           <span style={{ fontSize: "0.78rem", fontWeight: 700, color: "var(--burdeos)" }}>${s.precio}</span>
                           <span style={{ padding: "2px 8px", fontSize: "0.65rem", fontWeight: 700, background: badge.bg, color: badge.color, borderRadius: "var(--r-pill)" }}>{badge.label}</span>
+                          {enAlerta && <span title={`Costo actual: $${s.costoLive} · Margen: $${s.margenActual}`} style={{ padding: "2px 8px", fontSize: "0.65rem", fontWeight: 800, background: "#FF6F00", color: "#fff", borderRadius: "var(--r-pill)" }}>⚠️ Margen bajo</span>}
                           {s.tag && <span style={{ padding: "2px 8px", fontSize: "0.65rem", fontWeight: 700, background: s.tagColor || "var(--rosa)", color: s.tagText || "#fff", borderRadius: "var(--r-pill)" }}>{s.tag}</span>}
                           {s.esTemporada && <span style={{ padding: "2px 8px", fontSize: "0.65rem", fontWeight: 700, background: "#FFE99B", color: "#6B4F1A", borderRadius: "var(--r-pill)" }}>Temporada</span>}
                           {!s.activo && <span style={{ padding: "2px 8px", fontSize: "0.65rem", fontWeight: 700, background: "var(--border-strong)", color: "#fff", borderRadius: "var(--r-pill)" }}>Oculto</span>}
                         </div>
                       </div>
                     </div>
+
+                    {/* Bloque de detalle de costo (solo si la galleta tiene receta) */}
+                    {s.recetaId && (s.costoLive != null || s.costoUnitarioSnapshot != null) && (
+                      <div style={{ background: enAlerta ? "#fff3e0" : "#f8f8f8", borderRadius: "var(--r-md)", padding: "8px 10px", marginTop: 8, fontSize: "0.72rem", lineHeight: 1.5 }}>
+                        <div style={{ display: "flex", justifyContent: "space-between" }}>
+                          <span style={{ color: "var(--text-muted)" }}>Costo actual:</span>
+                          <span style={{ fontWeight: 700, color: enAlerta ? "#FF6F00" : "var(--burdeos)" }}>${s.costoLive ?? "—"}</span>
+                        </div>
+                        <div style={{ display: "flex", justifyContent: "space-between" }}>
+                          <span style={{ color: "var(--text-muted)" }}>Margen:</span>
+                          <span style={{ fontWeight: 700, color: enAlerta ? "#FF6F00" : "#1D5A45" }}>${s.margenActual ?? "—"}</span>
+                        </div>
+                        {s.costoUnitarioSnapshot != null && s.costoLive != null && Math.abs(s.costoLive - s.costoUnitarioSnapshot) > 0.01 && (
+                          <button
+                            type="button"
+                            onClick={() => handleRecostear(s)}
+                            style={{ marginTop: 6, width: "100%", padding: "4px 8px", background: "#fff", color: "var(--burdeos)", border: "1px solid var(--border-color)", borderRadius: "var(--r-md)", fontWeight: 700, fontSize: "0.7rem", cursor: "pointer" }}
+                            title={`Snapshot: $${s.costoUnitarioSnapshot} · Live: $${s.costoLive}`}
+                          >
+                            🔄 Recostear (snapshot quedó desfasado)
+                          </button>
+                        )}
+                      </div>
+                    )}
 
                     {/* Stock row */}
                     <div style={{ background: "#fff1f2", borderRadius: "var(--r-md)", padding: "10px 12px", margin: "0.75rem 0" }}>
@@ -483,6 +592,49 @@ export default function GalletasAdminPage() {
                   style={inputStyle}
                 />
               </label>
+
+              {/* Receta (opcional) — desde donde hereda el costo */}
+              <label style={{ gridColumn: "1 / -1" }}>
+                <span style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-soft)", display: "block", marginBottom: 4 }}>
+                  Receta asociada <em style={{ color: "var(--text-muted)" }}>(opcional — calcula precio sugerido)</em>
+                </span>
+                <select
+                  value={formData.recetaId}
+                  onChange={(e) => {
+                    const recetaId = e.target.value;
+                    setFormData((prev) => ({ ...prev, recetaId }));
+                    calcularPrecioDesdeReceta(recetaId);
+                  }}
+                  style={inputStyle}
+                  disabled={recetas.length === 0}
+                >
+                  <option value="">— Sin receta (precio manual) —</option>
+                  {recetas.map((r) => (
+                    <option key={r._id} value={r._id}>
+                      {r.nombre_receta} · {r.portions} pz · ${r.total_cost}
+                    </option>
+                  ))}
+                </select>
+                {recetas.length === 0 && <p style={{ fontSize: "0.7rem", color: "var(--text-muted)", marginTop: 4 }}>No hay recetas con porciones válidas. Crea una en /dashboard/costeorecetas.</p>}
+                {costeoBusy && <p style={{ fontSize: "0.75rem", color: "var(--rosa)", marginTop: 4 }}>Calculando…</p>}
+              </label>
+
+              {/* Breakdown del cálculo (si hay) */}
+              {costeoData && (
+                <div style={{ gridColumn: "1 / -1", background: "#fff1f2", borderRadius: "var(--r-md)", padding: "12px 14px", border: "1px dashed var(--rosa)" }}>
+                  <p style={{ margin: 0, fontSize: "0.72rem", fontWeight: 700, color: "var(--rosa)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 6 }}>Cálculo desde receta</p>
+                  <table style={{ width: "100%", fontSize: "0.85rem", lineHeight: 1.7 }}>
+                    <tbody>
+                      <tr><td style={{ color: "var(--text-soft)" }}>Materia prima por galleta:</td><td style={{ textAlign: "right", fontWeight: 700, color: "var(--burdeos)" }}>${costeoData.costoMateriaPrima}</td></tr>
+                      <tr><td style={{ color: "var(--text-soft)" }}>+ Branding / empaque:</td><td style={{ textAlign: "right", fontWeight: 700, color: "var(--burdeos)" }}>${costeoData.costoBranding}</td></tr>
+                      <tr><td style={{ color: "var(--text-soft)", borderTop: "1px solid var(--border-color)", paddingTop: 4 }}>Costo total:</td><td style={{ textAlign: "right", fontWeight: 800, color: "var(--burdeos)", borderTop: "1px solid var(--border-color)", paddingTop: 4 }}>${costeoData.costoTotal}</td></tr>
+                      <tr><td style={{ color: "var(--text-soft)" }}>+ Markup {costeoData.markupPct}%:</td><td style={{ textAlign: "right", fontWeight: 700, color: "#1D5A45" }}>${(costeoData.precioSugerido - costeoData.costoTotal).toFixed(2)}</td></tr>
+                      <tr><td style={{ color: "var(--burdeos)", fontWeight: 800, borderTop: "2px solid var(--rosa)", paddingTop: 6 }}>Precio sugerido:</td><td style={{ textAlign: "right", fontWeight: 900, color: "var(--burdeos)", fontSize: "1.1rem", borderTop: "2px solid var(--rosa)", paddingTop: 6 }}>${costeoData.precioSugerido}</td></tr>
+                    </tbody>
+                  </table>
+                  <p style={{ margin: "6px 0 0", fontSize: "0.7rem", color: "var(--text-muted)" }}>El precio abajo se autopobló con el sugerido. Puedes ajustarlo libremente.</p>
+                </div>
+              )}
 
               {/* Precio */}
               <label>

--- a/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
+++ b/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
@@ -12,9 +12,20 @@ const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
 
 export default function Conocenuestrosproductos() {
   const { register, handleSubmit, formState: { errors } } = useForm();
-  const [costData, setCostData] = useState({ fixedCosts: 0, laborCosts: 0 });
+  const [costData, setCostData] = useState({
+    fixedCosts: 0,
+    laborCosts: 0,
+    costoBrandingPorGalleta: 0,
+    markupGalletasPct: 60,
+    margenMinimoGalleta: 5,
+  });
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
   const { userToken } = useAuth();
+
+  // Form independiente para la sección de galletas — no se mezcla con
+  // el de fixedCosts/laborCosts para que el admin pueda guardar uno
+  // u otro sin tener que llenar los dos cada vez.
+  const galletasForm = useForm();
 
   useEffect(() => {
     const fetchCostData = async () => {
@@ -24,7 +35,8 @@ export default function Conocenuestrosproductos() {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         const data = await response.json();
-        setCostData(data);
+        // Merge con defaults para que campos faltantes no rompan el render
+        setCostData((prev) => ({ ...prev, ...data }));
       } catch (error) {
         console.error('Error al obtener los datos de costos:', error);
       }
@@ -46,25 +58,25 @@ export default function Conocenuestrosproductos() {
           laborCosts: data.laborCosts,
         }),
       });
-  
+
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
-  
+
       const result = await response.json();
       console.log('Costo actualizado exitosamente:', result);
-  
-      setCostData(result);
-  
+
+      setCostData((prev) => ({ ...prev, ...result }));
+
       Swal.fire({
         title: 'Costos actualizados',
         text: 'Los costos han sido actualizados correctamente.',
         icon: 'success',
-        timer: 2000, 
+        timer: 2000,
         timerProgressBar: true,
         showConfirmButton: false,
-        background: '#fff1f2', 
-        color: '#540027', 
+        background: '#fff1f2',
+        color: '#540027',
       });
     } catch (error) {
       console.error('Error al actualizar el costo:', error);
@@ -81,7 +93,53 @@ export default function Conocenuestrosproductos() {
       });
     }
   };
-  
+
+  // Guarda los 3 campos de galletas. fixedCosts/laborCosts se envían con
+  // su valor actual (no se quieren tocar pero el back los requiere para
+  // mantener compat con el form anterior).
+  const onSubmitGalletas = async (data) => {
+    try {
+      const response = await fetch(`${API_BASE}/costs`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${userToken}`,
+        },
+        body: JSON.stringify({
+          fixedCosts: costData.fixedCosts,
+          laborCosts: costData.laborCosts,
+          costoBrandingPorGalleta: parseFloat(data.costoBrandingPorGalleta) || 0,
+          markupGalletasPct: parseFloat(data.markupGalletasPct) || 0,
+          margenMinimoGalleta: parseFloat(data.margenMinimoGalleta) || 0,
+        }),
+      });
+
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const result = await response.json();
+      setCostData((prev) => ({ ...prev, ...result }));
+
+      Swal.fire({
+        title: 'Config de Galletas NY actualizada',
+        icon: 'success',
+        timer: 2000,
+        timerProgressBar: true,
+        showConfirmButton: false,
+        background: '#fff1f2',
+        color: '#540027',
+      });
+    } catch (error) {
+      console.error('Error al actualizar config galletas:', error);
+      Swal.fire({
+        title: 'Error',
+        text: 'No se pudo actualizar la configuración de galletas.',
+        icon: 'error',
+        timer: 2000,
+        showConfirmButton: false,
+        background: '#fff1f2',
+        color: '#540027',
+      });
+    }
+  };
 
   return (
     <div className={`text-text ${poppins.className}`}>
@@ -136,6 +194,95 @@ export default function Conocenuestrosproductos() {
             <p className="text-lg font-semibold">Costos actuales:</p>
             <p className="text-md">Costos fijos: {costData.fixedCosts} MXN</p>
             <p className="text-md">Mano de obra: {costData.laborCosts} MXN</p>
+          </div>
+
+          {/* ── Sección: Configuración de Galletas NY ───────────────── */}
+          <div className="border-t-2 border-secondary mt-8 pt-6">
+            <h2 className={`text-3xl px-6 ${sofia.className}`} style={{ color: "#540027" }}>
+              🍪 Configuración de Galletas NY
+            </h2>
+            <p className="text-sm px-6 mb-4" style={{ color: "#a78891" }}>
+              Estos valores alimentan el cálculo automático de precio sugerido al dar de alta un sabor desde una receta, y la vigilancia del margen mínimo.
+            </p>
+
+            <form onSubmit={galletasForm.handleSubmit(onSubmitGalletas)}>
+              <div className="flex flex-col md:flex-row items-center">
+                <p className="font-bold m-4">Costo de branding/empaque por galleta</p>
+                <div className="m-4">
+                  <label htmlFor="costoBrandingPorGalleta" className="block mb-2 text-sm font-medium">
+                    MXN por pieza
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    id="costoBrandingPorGalleta"
+                    defaultValue={costData.costoBrandingPorGalleta ?? 0}
+                    key={`branding-${costData.costoBrandingPorGalleta ?? 0}`}
+                    {...galletasForm.register("costoBrandingPorGalleta", { required: true })}
+                    className="bg-gray-50 border border-secondary text-sm rounded-lg block w-full p-2.5"
+                    placeholder="0.0"
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col md:flex-row items-center">
+                <p className="font-bold m-4">Markup sugerido para galletas</p>
+                <div className="m-4">
+                  <label htmlFor="markupGalletasPct" className="block mb-2 text-sm font-medium">
+                    Porcentaje (%)
+                  </label>
+                  <input
+                    type="number"
+                    step="1"
+                    min="0"
+                    id="markupGalletasPct"
+                    defaultValue={costData.markupGalletasPct ?? 60}
+                    key={`markup-${costData.markupGalletasPct ?? 60}`}
+                    {...galletasForm.register("markupGalletasPct", { required: true })}
+                    className="bg-gray-50 border border-secondary text-sm rounded-lg block w-full p-2.5"
+                    placeholder="60"
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col md:flex-row items-center">
+                <p className="font-bold m-4">Margen mínimo (alerta)</p>
+                <div className="m-4">
+                  <label htmlFor="margenMinimoGalleta" className="block mb-2 text-sm font-medium">
+                    MXN por galleta
+                  </label>
+                  <input
+                    type="number"
+                    step="0.5"
+                    min="0"
+                    id="margenMinimoGalleta"
+                    defaultValue={costData.margenMinimoGalleta ?? 5}
+                    key={`margen-${costData.margenMinimoGalleta ?? 5}`}
+                    {...galletasForm.register("margenMinimoGalleta", { required: true })}
+                    className="bg-gray-50 border border-secondary text-sm rounded-lg block w-full p-2.5"
+                    placeholder="5"
+                  />
+                  <p className="text-xs mt-1" style={{ color: "#a78891" }}>
+                    Si el costo sube y el margen actual baja de este valor, se envía notificación interna.
+                  </p>
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                className="shadow-md text-text bg-primary hover:bg-accent hover:text-white focus:ring-4 focus:outline-none font-medium rounded-lg text-sm w-96 sm:w-96 px-16 py-2.5 text-center m-4"
+              >
+                Guardar configuración de Galletas NY
+              </button>
+            </form>
+
+            <div className="m-4 p-4 rounded-lg" style={{ background: "#fff1f2" }}>
+              <p className="text-lg font-semibold" style={{ color: "#540027" }}>Config actual de galletas:</p>
+              <p className="text-md">Branding/empaque: ${costData.costoBrandingPorGalleta ?? 0} MXN/pieza</p>
+              <p className="text-md">Markup sugerido: {costData.markupGalletasPct ?? 60}%</p>
+              <p className="text-md">Margen mínimo (alerta): ${costData.margenMinimoGalleta ?? 5} MXN</p>
+            </div>
           </div>
         </main>
         <FooterDashboard />


### PR DESCRIPTION
## Summary

**PR front** de la feature en 2 partes. Requiere mergear primero [BackPastelero#61](https://github.com/mipasteleria/BackPastelero/pull/61) — sin el back, los endpoints no existen y la UI degrada graciosamente (dropdown vacío, sin breakdown, sin alertas).

## Flujo de usuario

### Crear/editar un sabor
1. Admin abre form de "Nuevo sabor" → ve dropdown nuevo **"Receta asociada"** (opcional).
2. Elige una receta → fetch automático a \`POST /galletaSabores/calcular-precio\` → aparece tarjeta con breakdown:
   ```
   Materia prima por galleta:  $12.50
   + Branding/empaque:         $3.00
   ─────────────
   Costo total:                $15.50
   + Markup 60%:               $9.30
   ─────────────
   Precio sugerido:            $24.80   ← se autopobla en el input
   ```
3. Admin puede ajustar el precio libremente.
4. Al guardar, el back congela \`costoUnitarioSnapshot\` con el costo actual de la receta.

### Listado con vigilancia de margen
- El GET usa \`?conMargen=true\` — para cada sabor con receta, el back calcula el costo "live" (en caso de que hayan subido los insumos) y devuelve \`margenActual\`.
- Si \`margenActual < margenMinimoGalleta\` (default $5):
  - Sabor se muestra con **borde naranja + glow + badge \"⚠️ Margen bajo\"**.
  - El back crea una \`Notificacion\` interna (idempotente, máx 1 por sabor cada 30 días).
- Si el snapshot quedó desfasado del costo live, aparece botón **\"🔄 Recostear (snapshot quedó desfasado)\"** que llama a \`POST /:id/recostear\`.
- El precio mostrado al cliente NO cambia automáticamente — el admin decide manualmente si subir.

### Config global
Nueva sección \"🍪 Configuración de Galletas NY\" en \`/dashboard/gastosfijosymanodeobra\`:
- Costo branding/empaque por galleta (MXN)
- Markup sugerido (%)
- Margen mínimo de alerta (MXN)

Form separado del de fixedCosts/laborCosts para que se puedan editar independientemente.

## Cambios

| Archivo | Líneas |
|---|---|
| \`pages/dashboard/galletas-ny/index.jsx\` | +168 (dropdown + breakdown + alerta + mini-card de costo + recostear) |
| \`pages/dashboard/gastosfijosymanodeobra.jsx\` | +169 (sección nueva con 3 inputs + form independiente) |

## Compatibilidad

- **Sabores existentes sin recetaId**: siguen funcionando exactamente igual. No tienen mini-card de costo, no salen con badge de alerta. El admin puede editarlos y asociarles receta cuando quiera.
- **Si no hay recetas con porciones**: el dropdown muestra solo la opción \"Sin receta\" + un texto que indica crear una en \`/dashboard/costeorecetas\`.
- **Si el back aún no está mergeado**: el endpoint \`/calcular-precio\` da 404 — el front lo captura con Swal y no rompe el form.

## Build local

- [x] \`npm install\` OK
- [x] \`npm run build\` OK — 50+ rutas compilan
- [x] Sin nuevos warnings de ESLint

## Test plan en preview

- [ ] Crear nuevo sabor sin receta → funciona como antes (precio manual)
- [ ] Crear nuevo sabor seleccionando receta → ve breakdown y precio autopoblado
- [ ] Ajustar precio sugerido manualmente → se guarda el valor del admin, no el sugerido
- [ ] Editar sabor existente, asociarle receta → se calcula breakdown al cargar el form
- [ ] Cambiar precio de un insumo de la receta → al refrescar /dashboard/galletas-ny el sabor afectado muestra costo actualizado, y si margen < $5 sale badge naranja
- [ ] Pulsar \"Recostear\" → el snapshot se actualiza, el badge desaparece (si era por desfase)
- [ ] Ver notificación en el bell icon del navbar admin cuando un sabor entra en alerta
- [ ] Configurar branding/markup/margen en /dashboard/gastosfijosymanodeobra → se persiste y afecta el cálculo de calcular-precio

🤖 Generated with [Claude Code](https://claude.com/claude-code)