### PR TITLE
feat(insumos): autocomplete de similares + manejo de duplicados (409)

### DIFF
--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
+import { useRouter } from "next/router";
 import NavbarAdmin from "@/src/components/navbar";
 import { Poppins as PoppinsFont, Sofia as SofiaFont } from "next/font/google";
 import Asideadmin from "@/src/components/asideadmin";
@@ -17,71 +18,123 @@ export default function NuevaReceta() {
     handleSubmit,
     formState: { errors },
     setValue,
+    watch,
   } = useForm();
   const [costPerUnit, setCostPerUnit] = useState(0);
   const { userToken } = useAuth();
+  const router = useRouter();
 
-  const onSubmit = (data) => {
-    console.log(data);
+  // ── Autocomplete: muestra insumos similares mientras se tipea el nombre.
+  // Hace fetch a /insumos/buscar-similares con debounce 400ms; ayuda al
+  // admin a no crear duplicados semánticos como "Macadamia" vs
+  // "Nuez de Macadamia".
+  const [suggestions, setSuggestions] = useState([]);
+  const [searchBusy, setSearchBusy] = useState(false);
+  const nameValue = watch("name", "");
+  const debounceRef = useRef(null);
 
-    fetch(`${API_BASE}/insumos`, {
-      method: "POST",
-      body: JSON.stringify(data),
-      headers: {
-        "Content-type": "application/json; charset=UTF-8",
-        Authorization: `Bearer ${userToken}`,
-      },
-    })
-      .then((response) => {
-        if (response.ok) {
-          Swal.fire({
-            title: "¡Éxito!",
-            text: "Insumo agregado correctamente.",
-            icon: "success",
-            timer: 2000,
-            timerProgressBar: true,
-            showConfirmButton: false,
-            background: "#fff1f2",
-            color: "#540027",
-          }).then(() => {
-            // Limpiar todos los campos manualmente
-            setValue("name", "");
-            setValue("amount", "");
-            setValue("cost", "");
-            setValue("unit", "");
-            setCostPerUnit(0); // Reiniciar el costo por unidad
-          });
-        } else {
-          return response.json().then((json) => {
-            console.error("Error:", json.message);
-            Swal.fire({
-              title: "Error",
-              text: json.message || "No se pudo agregar el insumo.",
-              icon: "error",
-              timer: 2000,
-              timerProgressBar: true,
-              showConfirmButton: false,
-              background: "#fff1f2",
-              color: "#540027",
-            });
-          });
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const q = (nameValue || "").trim();
+    if (q.length < 2) { setSuggestions([]); setSearchBusy(false); return; }
+    setSearchBusy(true);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`${API_BASE}/insumos/buscar-similares?q=${encodeURIComponent(q)}`);
+        if (res.ok) {
+          const json = await res.json();
+          setSuggestions(json.data || []);
         }
-      })
-      .catch((error) => {
-        console.error("Error:", error);
+      } catch (err) {
+        // Silencioso — el autocomplete es opcional.
+      } finally {
+        setSearchBusy(false);
+      }
+    }, 400);
+    return () => debounceRef.current && clearTimeout(debounceRef.current);
+  }, [nameValue]);
+
+  // ── Submit con manejo de 409 (duplicado bloqueado por el back).
+  const onSubmit = async (data) => {
+    try {
+      const response = await fetch(`${API_BASE}/insumos`, {
+        method: "POST",
+        body: JSON.stringify(data),
+        headers: {
+          "Content-type": "application/json; charset=UTF-8",
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      if (response.ok) {
         Swal.fire({
-          title: "Error",
-          text: "Error al conectar con el servidor.",
-          icon: "error",
+          title: "¡Éxito!",
+          text: "Insumo agregado correctamente.",
+          icon: "success",
           timer: 2000,
           timerProgressBar: true,
           showConfirmButton: false,
           background: "#fff1f2",
           color: "#540027",
+        }).then(() => {
+          setValue("name", "");
+          setValue("amount", "");
+          setValue("cost", "");
+          setValue("unit", "");
+          setCostPerUnit(0);
+          setSuggestions([]);
         });
+        return;
+      }
+
+      // Caso especial: duplicado detectado por el back
+      if (response.status === 409) {
+        const json = await response.json().catch(() => ({}));
+        const existente = json.existente;
+        const result = await Swal.fire({
+          title: "Insumo duplicado",
+          html: existente
+            ? `Ya existe <b>"${existente.name}"</b> con ${existente.amount} ${existente.unit} a $${existente.cost}.<br>¿Quieres editarlo en vez de crear uno nuevo?`
+            : json.message || "Ya existe un insumo con ese nombre.",
+          icon: "warning",
+          showCancelButton: !!existente,
+          confirmButtonText: existente ? "Editar el existente" : "Entendido",
+          cancelButtonText: "Cancelar",
+          background: "#fff1f2",
+          color: "#540027",
+        });
+        if (result.isConfirmed && existente) {
+          router.push(`/dashboard/insumosytrabajomanual/editarinsumosotrabajo/${existente._id}`);
+        }
+        return;
+      }
+
+      const json = await response.json().catch(() => ({}));
+      Swal.fire({
+        title: "Error",
+        text: json.message || "No se pudo agregar el insumo.",
+        icon: "error",
+        timer: 2000,
+        timerProgressBar: true,
+        showConfirmButton: false,
+        background: "#fff1f2",
+        color: "#540027",
       });
+    } catch (error) {
+      console.error("Error:", error);
+      Swal.fire({
+        title: "Error",
+        text: "Error al conectar con el servidor.",
+        icon: "error",
+        timer: 2000,
+        timerProgressBar: true,
+        showConfirmButton: false,
+        background: "#fff1f2",
+        color: "#540027",
+      });
+    }
   };
-  
+
   const handleQuantityChange = (e) => {
     const value = e.target.value;
     setValue("amount", value);
@@ -126,6 +179,7 @@ export default function NuevaReceta() {
                 <input
                   type="text"
                   id="recipe_name"
+                  autoComplete="off"
                   {...register("name", { required: "Nombre es requerido" })}
                   className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5 dark:placeholder-secondary dark:focus:ring-blue-500 dark:focus:border-accent"
                   placeholder="Pastel de vainilla"
@@ -133,8 +187,45 @@ export default function NuevaReceta() {
                 {errors.name && (
                   <p className="text-red-600">{errors.name.message}</p>
                 )}
+
+                {/* Sugerencias: aparecen cuando hay nombres similares ya
+                    en BD. No bloquean nada — solo avisan al admin para
+                    evitar duplicados semánticos ("Macadamia" vs
+                    "Nuez de Macadamia"). */}
+                {(searchBusy || suggestions.length > 0) && (
+                  <div
+                    className="mt-2 rounded-lg border p-3"
+                    style={{ background: "#fff8e1", borderColor: "#FFC107" }}
+                  >
+                    {searchBusy ? (
+                      <p className="text-xs" style={{ color: "#6B4F1A" }}>Buscando insumos similares…</p>
+                    ) : (
+                      <>
+                        <p className="text-xs font-semibold mb-2" style={{ color: "#6B4F1A" }}>
+                          ⚠️ Insumos similares ya en BD ({suggestions.length}). Revisa antes de duplicar:
+                        </p>
+                        <ul className="space-y-1">
+                          {suggestions.map((s) => (
+                            <li key={s._id} className="flex items-center justify-between text-sm">
+                              <span style={{ color: "#540027" }}>
+                                <b>{s.name}</b> · {s.amount} {s.unit} · ${s.cost}
+                              </span>
+                              <Link
+                                href={`/dashboard/insumosytrabajomanual/editarinsumosotrabajo/${s._id}`}
+                                className="text-xs underline"
+                                style={{ color: "#9c2a44" }}
+                              >
+                                Editar este
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
-              <div 
+              <div
               className="grid gap-6 mb-6">
                 <div>
                   <label
@@ -176,9 +267,9 @@ export default function NuevaReceta() {
                     <p className="text-red-600">{errors.cost.message}</p>
                   )}
                 </div>
-                <div 
+                <div
                 className="flex items-end">
-                  <div 
+                  <div
                   className="w-full">
                     <label
                       htmlFor="unit"
@@ -201,11 +292,11 @@ export default function NuevaReceta() {
                 </div>
               </div>
             </div>
-            <div 
+            <div
             className="m-4 w-3/4 mx-auto text-lg">
               Costo por unidad: {costPerUnit} por gramo/ml
             </div>
-            <div 
+            <div
             className="flex flex-col md:flex-row justify-center mb-10">
             <button
               type="submit"
@@ -213,8 +304,8 @@ export default function NuevaReceta() {
             >
               Agregar
             </button>
-            <Link 
-            className="" 
+            <Link
+            className=""
             href={"/dashboard/insumosytrabajomanual"}>
               <button
                 type=""

--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx
@@ -61,8 +61,6 @@ export default function EditarInsumo({ insumo }) {
   };
 
   const onSubmit = async (data) => {
-    console.log("ID del insumo:", insumo._id);
-  
     try {
       const response = await fetch(`${API_BASE}/insumos/${insumo._id}`, {
         method: "PUT",
@@ -72,7 +70,7 @@ export default function EditarInsumo({ insumo }) {
           Authorization: `Bearer ${userToken}`,
         },
       });
-  
+
       if (response.ok) {
         Swal.fire({
           title: "¡Insumo Actualizado!",
@@ -84,19 +82,42 @@ export default function EditarInsumo({ insumo }) {
           background: "#fff1f2",
           color: "#540027",
         });
-      } else {
-        const errorData = await response.json();
-        Swal.fire({
-          title: "Error",
-          text: errorData.message || "No se pudo editar el insumo o trabajo.",
-          icon: "error",
-          timer: 2000,
-          timerProgressBar: true,
-          showConfirmButton: false,
+        return;
+      }
+
+      // 409: el nuevo nombre choca con otro insumo existente
+      if (response.status === 409) {
+        const json = await response.json().catch(() => ({}));
+        const existente = json.existente;
+        const result = await Swal.fire({
+          title: "Nombre duplicado",
+          html: existente
+            ? `Ya existe otro insumo con el mismo nombre: <b>"${existente.name}"</b>.<br>Cambia el nombre o ve a editar ese otro.`
+            : json.message || "Ese nombre ya está en uso por otro insumo.",
+          icon: "warning",
+          showCancelButton: !!existente,
+          confirmButtonText: existente ? "Ir al otro insumo" : "Entendido",
+          cancelButtonText: "Cancelar",
           background: "#fff1f2",
           color: "#540027",
         });
+        if (result.isConfirmed && existente) {
+          router.push(`/dashboard/insumosytrabajomanual/editarinsumosotrabajo/${existente._id}`);
+        }
+        return;
       }
+
+      const errorData = await response.json().catch(() => ({}));
+      Swal.fire({
+        title: "Error",
+        text: errorData.message || "No se pudo editar el insumo o trabajo.",
+        icon: "error",
+        timer: 2000,
+        timerProgressBar: true,
+        showConfirmButton: false,
+        background: "#fff1f2",
+        color: "#540027",
+      });
     } catch (error) {
       console.error("Error:", error);
       Swal.fire({
@@ -110,7 +131,7 @@ export default function EditarInsumo({ insumo }) {
         color: "#540027",
       });
     }
-  };  
+  };
 
   return (
     <div className={`text-text ${poppins.className}`}>


### PR DESCRIPTION
## Summary

**PR front** de la feature. Requiere mergear primero [BackPastelero#63](https://github.com/mipasteleria/BackPastelero/pull/63) — sin el back, el endpoint de búsqueda devuelve 404 y el autocomplete queda silenciosamente vacío (no rompe nada, solo no sugiere).

## Cambios

### `pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx`

- **Autocomplete** mientras se escribe el nombre:
  - Debounce 400ms.
  - A partir de 2 caracteres hace \`GET /insumos/buscar-similares?q=...\`.
  - Muestra banner amarillo con hasta 5 sugerencias + CTA "Editar este" hacia el insumo existente.
  - Ayuda al admin a no crear duplicados semánticos antes de submit.

- **Manejo de 409 en submit**:
  - Si el back rechaza por duplicado normalizado, muestra Swal con el insumo existente (nombre, cantidad, costo).
  - Botón "Editar el existente" navega al form de edición.

### `pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx`

- **Manejo de 409 en submit**:
  - Si el admin renombra a un nombre que ya existe en otro insumo, muestra Swal con CTA "Ir al otro insumo".
- Sin autocomplete (la edición típica es cambio de cantidad/costo; el 409 cubre el rename accidental).

## Compatibilidad

- Si el back de esta feature aún no está deployado: el endpoint \`/insumos/buscar-similares\` devuelve 404, el front lo captura silencioso y simplemente no muestra sugerencias. El form sigue funcionando.
- Si el back está deployado pero todavía no hay duplicados en la base: autocomplete devuelve lista vacía → banner no aparece. Solo aparece cuando hay matches reales.

## Build local

- [x] \`npm run build\` OK — 50+ rutas compilan
- [x] Sin nuevos warnings de ESLint

## Test plan en preview

- [ ] Ir a \`/dashboard/insumosytrabajomanual/agregarinsumosotrabajo\`
- [ ] Tipear "Nuez" → si existe "Nuez de Macadamia" debería aparecer en sugerencias
- [ ] Crear un insumo nuevo "Harina", luego intentar crear "harina" → debe salir el Swal de duplicado con CTA al existente
- [ ] Editar un insumo y cambiar el nombre por uno que ya existe → debe salir el Swal de "nombre duplicado"
- [ ] Click en "Editar el existente" debe navegar a /editarinsumosotrabajo/{id}

🤖 Generated with [Claude Code](https://claude.com/claude-code)