### PR TITLE
fix(insumos): botón OK del Swal de merge era casi invisible

### DIFF
--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/index.jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/index.jsx
@@ -131,6 +131,8 @@ export default function InsumosyTrabajoManual() {
         html: `Se eliminaron <b>${eliminados}</b> duplicado(s).<br>${recetasUpd} receta(s) actualizadas.`,
         background: "#fff1f2",
         color: "#540027",
+        confirmButtonText: "Listo",
+        confirmButtonColor: "#540027",
       });
       setShowMergeModal(false);
       clearSelection();
@@ -143,6 +145,8 @@ export default function InsumosyTrabajoManual() {
         text: err.response?.data?.message || err.message,
         background: "#fff1f2",
         color: "#540027",
+        confirmButtonText: "Cerrar",
+        confirmButtonColor: "#9c2a44",
       });
     } finally {
       setMerging(false);


### PR DESCRIPTION
## Bug

Alberto reportó que el botón \"OK\" del Swal de confirmación tras hacer merge es casi invisible (texto gris claro sobre fondo rosa #fff1f2). Imposible darle click si no buscas el área exacta.

## Causa

En \`pages/dashboard/insumosytrabajomanual/index.jsx\`, el Swal de éxito del merge no tenía \`confirmButtonColor\` ni \`confirmButtonText\` definidos — usa los defaults de SweetAlert, que no contrastan con el background custom \`#fff1f2\`.

## Fix

Aplicado al Swal de éxito y al de error del merge:

| Swal | confirmButtonText | confirmButtonColor |
|---|---|---|
| Éxito | \"Listo\" | \`#540027\` (burdeos) |
| Error | \"Cerrar\" | \`#9c2a44\` (rosa oscuro) |

Consistente con el resto del proyecto (handleDelete ya usa esos colores).

## Test plan

- [ ] Marcar 2+ insumos, fusionar
- [ ] Verificar que el botón del Swal de éxito ahora es visible (burdeos sobre rosa)
- [ ] Forzar un error (apagar el back, intentar merge) → botón rojo \"Cerrar\" visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)