### PR TITLE
feat(insumos): agregar "piezas" como unidad

### DIFF
--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/agregarinsumosotrabajo.jsx
@@ -284,6 +284,7 @@ export default function NuevaReceta() {
                     >
                       <option value="gr">gramos</option>
                       <option value="ml">mililitros</option>
+                      <option value="pza">piezas</option>
                     </select>
                     {errors.unit && (
                       <p className="text-red-600">{errors.unit.message}</p>
@@ -294,7 +295,7 @@ export default function NuevaReceta() {
             </div>
             <div
             className="m-4 w-3/4 mx-auto text-lg">
-              Costo por unidad: {costPerUnit} por gramo/ml
+              Costo unitario: {costPerUnit}
             </div>
             <div
             className="flex flex-col md:flex-row justify-center mb-10">

--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/editarinsumosotrabajo/[id].jsx
@@ -221,6 +221,7 @@ export default function EditarInsumo({ insumo }) {
                     >
                       <option value="gr">gramos</option>
                       <option value="ml">mililitros</option>
+                      <option value="pza">piezas</option>
                     </select>
                     {errors.unit && (
                       <p className="text-red-600">{errors.unit.message}</p>
@@ -230,7 +231,7 @@ export default function EditarInsumo({ insumo }) {
               </div>
             </div>
             <div className="m-4 w-3/4 mx-auto text-lg">
-              Costo por unidad: {costPerUnit} por gramo/ml
+              Costo unitario: {costPerUnit}
             </div>
             <div className="flex flex-col md:flex-row justify-center mb-10">
             <button

--- a/front-pastelero/pages/dashboard/insumosytrabajomanual/index.jsx
+++ b/front-pastelero/pages/dashboard/insumosytrabajomanual/index.jsx
@@ -211,7 +211,7 @@ export default function InsumosyTrabajoManual() {
                     <th scope="col" className="px-6 py-3 border-b border-secondary">Cantidad</th>
                     <th scope="col" className="px-6 py-3 border-b border-secondary">Costo</th>
                     <th scope="col" className="px-6 py-3 border-b border-secondary">Unidad</th>
-                    <th scope="col" className="px-6 py-3 border-b border-secondary">Precio por gr/ml</th>
+                    <th scope="col" className="px-6 py-3 border-b border-secondary">Precio unitario</th>
                     <th scope="col" className="px-6 py-3 border-b border-secondary">Acciones</th>
                   </tr>
                 </thead>


### PR DESCRIPTION
## Summary

Alberto reportó que el dropdown de unidad solo aceptaba \"gramos\" y \"mililitros\". Faltaba la opción para insumos que se cuentan por pieza (huevos, frutas enteras, empaques, etiquetas, etc.).

## Cambios

| Archivo | Cambio |
|---|---|
| \`agregarinsumosotrabajo.jsx\` | +\`<option value=\"pza\">piezas</option>\` |
| \`editarinsumosotrabajo/[id].jsx\` | +\`<option value=\"pza\">piezas</option>\` |
| Labels en ambos forms | \"Costo por unidad: X por gramo/ml\" → \"Costo unitario: X\" |
| Header listado | \"Precio por gr/ml\" → \"Precio unitario\" |

## Sin cambios en el back

- El modelo solo guarda el string \`unit\` con validación de longitud (1-20 chars).
- El cálculo \`cost / amount\` funciona igual para piezas:
  - Ej: \$30 / 12 huevos = \$2.50 por pieza.

## Test plan en preview

- [ ] Ir a \`/dashboard/insumosytrabajomanual/agregarinsumosotrabajo\`
- [ ] Verificar que el dropdown ahora muestra: gramos, mililitros, **piezas**
- [ ] Crear \"Huevos\" con cantidad 12, costo 30, unidad piezas → \"Costo unitario: 2.50\"
- [ ] Verificar que aparece en el listado con \"piezas\" en unidad y 2.50 en precio unitario
- [ ] Editar el insumo y cambiar unidad → debería abrir con \"piezas\" pre-seleccionado

🤖 Generated with [Claude Code](https://claude.com/claude-code)