### PR TITLE
fix(galletas-checkout): DatePicker con domingos deshabilitados + 48h mínimo

### DIFF
--- a/front-pastelero/package-lock.json
+++ b/front-pastelero/package-lock.json
@@ -20,6 +20,7 @@
         "next": "^15.5.18",
         "react": "^18.3.1",
         "react-calendar": "^5.0.0",
+        "react-datepicker": "^9.1.0",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.2",
         "react-router-dom": "^6.26.1",
@@ -5676,6 +5677,52 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-datepicker": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-9.1.0.tgz",
+      "integrity": "sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.15",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "date-fns-tz": "^3.0.0",
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "date-fns-tz": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-datepicker/node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/react-datepicker/node_modules/date-fns": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/front-pastelero/package.json
+++ b/front-pastelero/package.json
@@ -21,6 +21,7 @@
     "next": "^15.5.18",
     "react": "^18.3.1",
     "react-calendar": "^5.0.0",
+    "react-datepicker": "^9.1.0",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.2",
     "react-router-dom": "^6.26.1",

--- a/front-pastelero/pages/enduser/galletas-checkout.jsx
+++ b/front-pastelero/pages/enduser/galletas-checkout.jsx
@@ -5,9 +5,14 @@ import { loadStripe } from "@stripe/stripe-js";
 import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js";
 import axios from "axios";
 import Swal from "sweetalert2";
+import DatePicker, { registerLocale } from "react-datepicker";
+import { es } from "date-fns/locale";
+import "react-datepicker/dist/react-datepicker.css";
 import NavbarAdmin from "@/src/components/navbar";
 import WebFooter from "@/src/components/WebFooter";
 import { Sofia as SofiaFont, Nunito as NunitoFont } from "next/font/google";
+
+registerLocale("es", es);
 
 const sofia  = SofiaFont({ subsets: ["latin"], weight: ["400"] });
 const nunito = NunitoFont({ subsets: ["latin"], weight: ["400", "600", "700", "800"] });
@@ -33,19 +38,30 @@ const SLOTS_ENVIO = [
 ];
 
 /* ─── Helpers ────────────────────────────────────────────────── */
-function getMinDateString() {
-  // 72h from now → date string YYYY-MM-DD (in local TZ)
-  const d = new Date(Date.now() + 72 * 60 * 60 * 1000);
-  // bump to Monday if it lands on Sunday
+function getMinDate() {
+  const d = new Date(Date.now() + 48 * 60 * 60 * 1000);
   if (d.getDay() === 0) d.setDate(d.getDate() + 1);
-  return d.toISOString().split("T")[0];
+  return d;
 }
 
 function isSunday(dateString) {
   if (!dateString) return false;
-  // Parse as local-date (avoid TZ shift)
   const [y, m, d] = dateString.split("-").map(Number);
   return new Date(y, m - 1, d).getDay() === 0;
+}
+
+function dateToYMD(d) {
+  if (!d) return "";
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function ymdToDate(s) {
+  if (!s) return null;
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
 }
 
 /* ─── Component ──────────────────────────────────────────────── */
@@ -149,7 +165,7 @@ export default function GalletasCheckout() {
 
   /* ── Available time slots ── */
   const slotsDisponibles = tipoEntrega === "envio" ? SLOTS_ENVIO : SLOTS_RECOGIDA;
-  const minDate = getMinDateString();
+  const minDate = getMinDate();
 
   /* ── Form validation ── */
   const formValido = useMemo(() => {
@@ -357,21 +373,21 @@ export default function GalletasCheckout() {
             {/* Step 3 — Fecha + hora */}
             <Section number="3" title="¿Cuándo lo necesitas?">
               <p style={{ fontSize: "0.78rem", color: "var(--text-muted)", marginBottom: 8 }}>
-                Mínimo 72 horas de anticipación. Lunes a Sábado.
+                Mínimo 48 horas de anticipación. Lunes a Sábado.
               </p>
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem" }}>
                 <Field label="Fecha de entrega *">
-                  <input type="date" required min={minDate} value={fecha}
-                    onChange={(e) => {
-                      const v = e.target.value;
-                      if (v && isSunday(v)) {
-                        Swal.fire({ icon: "info", title: "Día no disponible", text: "No realizamos entregas los domingos.", timer: 2200, showConfirmButton: false });
-                        setFecha("");
-                      } else {
-                        setFecha(v);
-                      }
-                    }}
-                    style={inputStyle} />
+                  <DatePicker
+                    selected={ymdToDate(fecha)}
+                    onChange={(d) => setFecha(dateToYMD(d))}
+                    minDate={minDate}
+                    filterDate={(d) => d.getDay() !== 0}
+                    locale="es"
+                    dateFormat="dd/MM/yyyy"
+                    placeholderText="Selecciona una fecha"
+                    customInput={<input style={inputStyle} />}
+                    required
+                  />
                 </Field>
                 <Field label="Hora de entrega *">
                   <select required value={hora} onChange={(e) => setHora(e.target.value)} style={inputStyle}>


### PR DESCRIPTION
## Summary
- Reemplaza el `<input type="date">` nativo por **react-datepicker** en `pages/enduser/galletas-checkout.jsx`. El nativo NO permite tachar visualmente los domingos ni respeta `min` en todos los celulares, así que el usuario podía elegir días no disponibles y solo recibía el error al validar.
- Anticipación mínima: **72h → 48h** (alineado con [BackPastelero#69](https://github.com/mipasteleria/BackPastelero/pull/69)).
- Locale `es` en el calendario (meses/días en español).
- Texto "Mínimo 72 horas" → "Mínimo 48 horas".

## Detalles técnicos
- Nueva dep: `react-datepicker@^9.1.0` (incluye date-fns como peer).
- `getMinDateString()` → `getMinDate()` (ahora retorna Date object).
- Helpers `dateToYMD` / `ymdToDate` para mantener el `fecha` del state como string `YYYY-MM-DD` (no romper el payload `fechaEntrega` que se envía al back).
- Domingos se filtran con `filterDate={(d) => d.getDay() !== 0}` (se ven tachados en el calendario, no clicables).
- `customInput={<input style={inputStyle} />}` para conservar el look del resto del form.

## Bundle
La página `enduser/galletas-checkout` quedó en 58.7 kB / 203 kB First Load (vs ~135 kB anterior). El costo es razonable por el UX correcto del calendario.

## Test plan
- [ ] Abrir `/enduser/galletas-checkout` desde celular en inglés: el calendario debe mostrar nombres en español.
- [ ] Confirmar que los domingos aparecen tachados/grises y no se pueden seleccionar.
- [ ] Confirmar que las fechas a menos de 48h aparecen deshabilitadas.
- [ ] Seleccionar una fecha válida → enviar → ver la pasarela de Stripe.
- [ ] Una vez mergeado el PR del back, confirmar que la pasarela carga en español.

🤖 Generated with [Claude Code](https://claude.com/claude-code)