### PR TITLE
fix(galletas-checkout): minDate al primer día COMPLETO disponible

### DIFF
--- a/front-pastelero/pages/enduser/galletas-checkout.jsx
+++ b/front-pastelero/pages/enduser/galletas-checkout.jsx
@@ -38,10 +38,25 @@ const SLOTS_ENVIO = [
 ];
 
 /* ─── Helpers ────────────────────────────────────────────────── */
+// Primer día disponible para entrega: aquel donde el slot más temprano
+// (10:00, primero de recogida) ya cae a >=48h de ahora. Sin este
+// "redondeo al siguiente día", DatePicker permitía elegir un día que
+// el back rechazaba porque algunas horas tempranas aún estaban dentro
+// de la ventana de 48h. Saltamos también los domingos.
 function getMinDate() {
-  const d = new Date(Date.now() + 48 * 60 * 60 * 1000);
-  if (d.getDay() === 0) d.setDate(d.getDate() + 1);
-  return d;
+  const FIRST_SLOT_HOUR = 10; // primer slot del día (recogida)
+  const target = new Date(Date.now() + 48 * 60 * 60 * 1000);
+  // Si la hora "ahora+48h" cae después de las 10:00, ese día ya no es
+  // completamente válido — saltar al siguiente día completo.
+  if (
+    target.getHours() > FIRST_SLOT_HOUR ||
+    (target.getHours() === FIRST_SLOT_HOUR && (target.getMinutes() > 0 || target.getSeconds() > 0))
+  ) {
+    target.setDate(target.getDate() + 1);
+  }
+  target.setHours(0, 0, 0, 0);
+  if (target.getDay() === 0) target.setDate(target.getDate() + 1);
+  return target;
 }
 
 function isSunday(dateString) {


### PR DESCRIPTION
## Bug
Alberto reportó que el DatePicker permitía elegir un día (ej. el 25) que luego el back rechazaba con error de 48h. Causa: \`minDate\` era \`ahora + 48h\` (Date con hora). React-datepicker compara a nivel de día (sin hora), así que mostraba habilitado el día donde +48h cae, aunque las horas tempranas de ese día (10:00, 11:00) todavía estuvieran dentro de la ventana.

## Fix
\`getMinDate()\` ahora salta al siguiente día completo si la hora \"ahora+48h\" cae después del primer slot del día (10:00). Resultado: solo se muestran días donde TODAS las horas son >=48h.

Domingos se siguen saltando al lunes.

## Acompaña
[BackPastelero#?](https://github.com/mipasteleria/BackPastelero/pulls) — fix del bug TZ en \`validarFechaHora\` que era el otro lado del mismo problema (el back rechazaba el primer día porque interpretaba \`new Date(\"YYYY-MM-DD\")\` como UTC midnight).

## Test plan
- [ ] Abrir checkout: el primer día seleccionable debe ser >=48h después de la hora actual contando el slot 10:00.
- [ ] Confirmar que ya no aparecen fechas que el back rechazaría.
- [ ] Confirmar que domingos siguen tachados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)