### PR TITLE
feat(home): hero, navbar y categorías ajustados

### DIFF
--- a/front-pastelero/pages/index.jsx
+++ b/front-pastelero/pages/index.jsx
@@ -11,7 +11,7 @@ const nunito = NunitoFont({ subsets: ["latin"], weight: ["400", "600", "700", "8
 const CATS = [
   { href: "/enduser/pastel-vintage", label: "Pasteles Vintage", sub: "Ármalo a tu gusto",      bg: "linear-gradient(180deg,rgba(255,226,231,.7) 0%,#FFC3C9 100%)", emoji: "🎂", textColor: "var(--burdeos)" },
   { href: "/enduser/galletas-ny",    label: "Galletas NY",      sub: "Mega, suaves, rellenas",  bg: "linear-gradient(180deg,rgba(184,230,211,.7) 0%,#B8E6D3 100%)", emoji: "🍪", textColor: "var(--burdeos)" },
-  { href: "/enduser/conocenuestrosproductos", label: "Cupcakes", sub: "Perfectos para eventos", bg: "linear-gradient(180deg,rgba(255,233,155,.7) 0%,#FFE99B 100%)", emoji: "🧁", textColor: "var(--burdeos)" },
+  { href: "/cotizacion",             label: "Cotización personalizada", sub: "A tu medida",         bg: "linear-gradient(180deg,rgba(255,233,155,.7) 0%,#FFE99B 100%)", emoji: "📝", textColor: "var(--burdeos)" },
   { href: "/cursos",                 label: "Cursos",            sub: "Aprende con nosotros",   bg: "linear-gradient(180deg,rgba(217,196,232,.7) 0%,#D9C4E8 100%)", emoji: "✨", textColor: "var(--burdeos)" },
 ];
 
@@ -78,9 +78,8 @@ export default function Home() {
             </div>
 
             <h1 className={sofia.className} style={{ fontSize: "clamp(3.5rem, 8vw, 6.5rem)", lineHeight: 0.97, color: "var(--burdeos)", marginBottom: "1.25rem" }}>
-              Hornea<br />
-              recuerdos
-              <span style={{ color: "var(--rosa)", display: "block", transform: "translateX(clamp(1.5rem,3vw,3rem))" }}>dulces.</span>
+              Horneando
+              <span style={{ color: "var(--rosa)", display: "block", transform: "translateX(clamp(1.5rem,3vw,3rem))" }}>recuerdos.</span>
             </h1>
 
             <p style={{ fontSize: "1.05rem", color: "var(--text-soft)", maxWidth: "46ch", lineHeight: 1.7, marginBottom: "2rem" }}>

--- a/front-pastelero/src/components/navbar.jsx
+++ b/front-pastelero/src/components/navbar.jsx
@@ -392,8 +392,8 @@ const NavbarAdmin = () => {
             {!isLoggedIn && (
               <div className="hidden md:flex items-center gap-3">
                 <Link href="/registrarse" style={linkStyle}>Registrarse</Link>
-                <Link href="/enduser/conocenuestrosproductos" style={linkStyle}>Productos</Link>
-                <Link href="/enduser/galeria" className="hidden lg:inline" style={linkStyle}>Galería</Link>
+                <Link href="/enduser/galletas-ny" style={linkStyle}>Galletas NY</Link>
+                <Link href="/enduser/pastel-vintage" className="hidden lg:inline" style={linkStyle}>Vintage Cake</Link>
                 <Link href="/login" style={linkStyle}>Iniciar sesión</Link>
                 <Link href="/enduser/conocenos#preguntasfrecuentes">
                   <button
@@ -561,8 +561,8 @@ const NavbarAdmin = () => {
                       {userEmail}
                     </div>
                     {[
-                      { href: "/enduser/conocenuestrosproductos", label: "Productos" },
-                      { href: "/enduser/galeria", label: "Galería" },
+                      { href: "/enduser/galletas-ny", label: "Galletas NY" },
+                      { href: "/enduser/pastel-vintage", label: "Vintage Cake" },
                       { href: "/enduser/mispedidos", label: "Mis Pedidos" },
                     ].map((item) => (
                       <Link
@@ -616,8 +616,8 @@ const NavbarAdmin = () => {
                 <>
                   {[
                     { href: "/registrarse", label: "Registrarse" },
-                    { href: "/enduser/conocenuestrosproductos", label: "Productos" },
-                    { href: "/enduser/galeria", label: "Galería" },
+                    { href: "/enduser/galletas-ny", label: "Galletas NY" },
+                    { href: "/enduser/pastel-vintage", label: "Vintage Cake" },
                     { href: "/login", label: "Iniciar sesión" },
                     { href: "/enduser/conocenos#preguntasfrecuentes", label: "Preguntas frecuentes" },
                   ].map((item) => (


### PR DESCRIPTION
## Resumen

Cambios de texto/links en el home (pedidos en sesión 22 may 2026). Pequeños y aislados.

### Hero
\"Hornea recuerdos dulces.\" → \"Horneando recuerdos.\" (palabra \"recuerdos\" mantiene el estilo rosa indentado).

### Navbar — quitar \"Productos\" y \"Galería\", agregar \"Galletas NY\" y \"Vintage Cake\"
Aplica en los 3 lugares:
- Desktop GUEST
- Mobile drawer USER (no admin)
- Mobile drawer GUEST

### Sección \"¿Qué se te antoja hoy?\"
Card de \"Cupcakes\" → \"Cotización personalizada\" (apuntaba a \`conocenuestrosproductos\` obsoleto; ahora va a \`/cotizacion\`). Emoji 🧁 → 📝, sub \"A tu medida\".

## Pendiente para PRs siguientes (no incluido aquí)
- Imagen PNG subible por admin para reemplazar el emoji 🎂 del hero
- Botones \"Favorito de la semana\" y \"Nuevo sabor\" linkeables a producto desde dashboard
- Sistema \"Top postres\" con CRUD admin + carrito (alcance grande, sesión aparte)
- Reseñas verificadas por compra (alcance grande, sesión aparte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)