### PR TITLE
feat(home-config): editor admin + chips linkeables en el hero

### DIFF
--- a/front-pastelero/pages/dashboard/home-config.jsx
+++ b/front-pastelero/pages/dashboard/home-config.jsx
@@ -1,0 +1,279 @@
+import { useEffect, useState } from "react";
+import NavbarAdmin from "@/src/components/navbar";
+import Asideadmin from "@/src/components/asideadmin";
+import FooterDashboard from "@/src/components/footeradmin";
+import Swal from "sweetalert2";
+import { useAuth } from "@/src/context";
+import { Poppins as PoppinsFont, Sofia as SofiaFont } from "next/font/google";
+
+const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
+const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const HREF_SUGERIDOS = [
+  { value: "/enduser/galletas-ny",    label: "Galletas NY" },
+  { value: "/enduser/pastel-vintage", label: "Pastel Vintage" },
+  { value: "/cotizacion",             label: "Cotización personalizada" },
+  { value: "/cursos",                 label: "Cursos" },
+];
+
+export default function HomeConfig() {
+  const { userToken } = useAuth();
+  const [cfg, setCfg] = useState({
+    imagenHeroUrl: "",
+    imagenHeroFileName: "",
+    favoritoSemanaHref: "/enduser/galletas-ny",
+    nuevoSaborHref:     "/enduser/galletas-ny",
+  });
+  const [loading, setLoading]   = useState(true);
+  const [saving, setSaving]     = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  /* ── Load current config ── */
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${API_BASE}/home-config`);
+        const j = await r.json();
+        if (j?.data) setCfg((prev) => ({ ...prev, ...j.data }));
+      } catch (e) {
+        console.error("Error cargando home-config:", e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  /* ── Save hrefs ── */
+  const guardarHrefs = async () => {
+    setSaving(true);
+    try {
+      const r = await fetch(`${API_BASE}/home-config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${userToken}` },
+        body: JSON.stringify({
+          favoritoSemanaHref: cfg.favoritoSemanaHref,
+          nuevoSaborHref:     cfg.nuevoSaborHref,
+        }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const j = await r.json();
+      setCfg((prev) => ({ ...prev, ...j.data }));
+      Swal.fire({ icon: "success", title: "Guardado", timer: 1500, showConfirmButton: false, background: "#fff1f2", color: "#540027" });
+    } catch (e) {
+      console.error(e);
+      Swal.fire({ icon: "error", title: "No se pudo guardar", text: String(e.message || e), background: "#fff1f2", color: "#540027" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /* ── Upload image + persist URL ── */
+  const handleFileChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      Swal.fire({ icon: "warning", title: "Debe ser una imagen (PNG recomendado, sin fondo)", background: "#fff1f2", color: "#540027" });
+      return;
+    }
+    setUploading(true);
+    try {
+      // 1) Subir a GCS via POST /upload
+      const fd = new FormData();
+      fd.append("files", file);
+      const upRes = await fetch(`${API_BASE}/upload`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${userToken}` },
+        body: fd,
+      });
+      if (!upRes.ok) throw new Error("Error al subir el archivo");
+      const upJson = await upRes.json();
+      const uploaded = Array.isArray(upJson) ? upJson[0] : upJson;
+      if (!uploaded?.fileUrl) throw new Error("Respuesta de upload incompleta");
+
+      // 2) Guardar la URL en home-config
+      const cfgRes = await fetch(`${API_BASE}/home-config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${userToken}` },
+        body: JSON.stringify({
+          imagenHeroUrl:      uploaded.fileUrl,
+          imagenHeroFileName: uploaded.fileName || "",
+        }),
+      });
+      if (!cfgRes.ok) throw new Error("Error al guardar la imagen en la configuración");
+      const cfgJson = await cfgRes.json();
+      setCfg((prev) => ({ ...prev, ...cfgJson.data }));
+      Swal.fire({ icon: "success", title: "Imagen actualizada", timer: 1500, showConfirmButton: false, background: "#fff1f2", color: "#540027" });
+    } catch (err) {
+      console.error(err);
+      Swal.fire({ icon: "error", title: "No se pudo subir", text: String(err.message || err), background: "#fff1f2", color: "#540027" });
+    } finally {
+      setUploading(false);
+      e.target.value = ""; // permite re-subir el mismo archivo
+    }
+  };
+
+  /* ── Remove image ── */
+  const quitarImagen = async () => {
+    const confirm = await Swal.fire({
+      icon: "question",
+      title: "¿Quitar la imagen del hero?",
+      text: "Volverá a mostrarse el emoji 🎂 mientras no haya nueva imagen.",
+      showCancelButton: true,
+      confirmButtonText: "Sí, quitar",
+      cancelButtonText: "Cancelar",
+      background: "#fff1f2",
+      color: "#540027",
+    });
+    if (!confirm.isConfirmed) return;
+    setSaving(true);
+    try {
+      const r = await fetch(`${API_BASE}/home-config`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${userToken}` },
+        body: JSON.stringify({ imagenHeroUrl: "", imagenHeroFileName: "" }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const j = await r.json();
+      setCfg((prev) => ({ ...prev, ...j.data }));
+    } catch (e) {
+      console.error(e);
+      Swal.fire({ icon: "error", title: "No se pudo quitar", background: "#fff1f2", color: "#540027" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={`text-text ${poppins.className}`}>
+      <NavbarAdmin className="fixed top-0 w-full z-50" />
+      <div className="flex flex-row mt-16">
+        <Asideadmin />
+        <main className="flex-grow md:w-3/4 mb-14 max-w-screen-lg mx-auto">
+          <h1 className={`text-4xl p-6 ${sofia.className}`}>Configuración del Home</h1>
+
+          {loading ? (
+            <p className="px-6">Cargando…</p>
+          ) : (
+            <div className="space-y-8 px-6 pb-10">
+
+              {/* ── Imagen del hero ────────────────────────── */}
+              <section className="border border-secondary rounded-2xl p-6 bg-white">
+                <h2 className={`text-2xl mb-2 ${sofia.className}`}>Imagen del hero</h2>
+                <p className="text-sm text-gray-600 mb-4">
+                  Reemplaza el emoji 🎂 que aparece en el círculo central del home. Sube un PNG con fondo transparente para que se vea el fondo de la animación.
+                </p>
+
+                <div className="flex flex-col md:flex-row items-start gap-6">
+                  <div
+                    style={{
+                      width: 180, height: 180, borderRadius: "50%",
+                      background: "var(--crema, #FFF6EC)",
+                      display: "flex", alignItems: "center", justifyContent: "center",
+                      border: "1px dashed #ddd", overflow: "hidden",
+                    }}
+                  >
+                    {cfg.imagenHeroUrl ? (
+                      <img src={cfg.imagenHeroUrl} alt="Imagen del hero" style={{ maxWidth: "85%", maxHeight: "85%", objectFit: "contain" }} />
+                    ) : (
+                      <span style={{ fontSize: "4rem" }}>🎂</span>
+                    )}
+                  </div>
+
+                  <div className="flex-1 space-y-3">
+                    <label className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-burdeos text-white font-bold cursor-pointer hover:opacity-90 transition" style={{ background: "var(--burdeos)" }}>
+                      <input type="file" accept="image/png,image/webp,image/jpeg" onChange={handleFileChange} disabled={uploading || saving} style={{ display: "none" }} />
+                      {uploading ? "Subiendo…" : (cfg.imagenHeroUrl ? "Reemplazar imagen" : "Subir imagen")}
+                    </label>
+                    {cfg.imagenHeroUrl && (
+                      <button
+                        onClick={quitarImagen}
+                        disabled={uploading || saving}
+                        className="ml-3 px-4 py-2 rounded-full font-bold border border-secondary hover:bg-rosa-4 transition"
+                        style={{ color: "var(--burdeos)" }}
+                      >
+                        Quitar imagen
+                      </button>
+                    )}
+                    <p className="text-xs text-gray-500">PNG (recomendado), WEBP o JPG. Máx 8 MB.</p>
+                  </div>
+                </div>
+              </section>
+
+              {/* ── Favorito de la semana ─────────────────── */}
+              <section className="border border-secondary rounded-2xl p-6 bg-white">
+                <h2 className={`text-2xl mb-2 ${sofia.className}`}>Favorito de la semana</h2>
+                <p className="text-sm text-gray-600 mb-4">
+                  Cuando el cliente da click en el chip "Favorito de la semana" del home, lo llevamos a esta URL. Útil para resaltar un producto en particular.
+                </p>
+                <label className="block mb-2 text-sm font-medium">URL destino</label>
+                <input
+                  type="text"
+                  value={cfg.favoritoSemanaHref}
+                  onChange={(e) => setCfg((p) => ({ ...p, favoritoSemanaHref: e.target.value }))}
+                  className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5"
+                  placeholder="/enduser/galletas-ny"
+                />
+                <p className="text-xs text-gray-500 mt-2">
+                  Sugerencias:{" "}
+                  {HREF_SUGERIDOS.map((s, i) => (
+                    <button
+                      key={s.value}
+                      onClick={() => setCfg((p) => ({ ...p, favoritoSemanaHref: s.value }))}
+                      type="button"
+                      className="underline hover:no-underline"
+                      style={{ color: "var(--burdeos)", marginRight: 10 }}
+                    >
+                      {s.label}
+                    </button>
+                  ))}
+                </p>
+              </section>
+
+              {/* ── Nuevo sabor ───────────────────────────── */}
+              <section className="border border-secondary rounded-2xl p-6 bg-white">
+                <h2 className={`text-2xl mb-2 ${sofia.className}`}>Nuevo sabor</h2>
+                <p className="text-sm text-gray-600 mb-4">
+                  Destino del chip "Nuevo sabor" del home.
+                </p>
+                <label className="block mb-2 text-sm font-medium">URL destino</label>
+                <input
+                  type="text"
+                  value={cfg.nuevoSaborHref}
+                  onChange={(e) => setCfg((p) => ({ ...p, nuevoSaborHref: e.target.value }))}
+                  className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5"
+                  placeholder="/enduser/galletas-ny"
+                />
+                <p className="text-xs text-gray-500 mt-2">
+                  Sugerencias:{" "}
+                  {HREF_SUGERIDOS.map((s) => (
+                    <button
+                      key={s.value}
+                      onClick={() => setCfg((p) => ({ ...p, nuevoSaborHref: s.value }))}
+                      type="button"
+                      className="underline hover:no-underline"
+                      style={{ color: "var(--burdeos)", marginRight: 10 }}
+                    >
+                      {s.label}
+                    </button>
+                  ))}
+                </p>
+              </section>
+
+              <button
+                onClick={guardarHrefs}
+                disabled={saving || uploading}
+                className="px-6 py-3 rounded-full text-white font-bold transition disabled:opacity-50"
+                style={{ background: "var(--burdeos)" }}
+              >
+                {saving ? "Guardando…" : "Guardar URLs"}
+              </button>
+            </div>
+          )}
+        </main>
+      </div>
+      <FooterDashboard />
+    </div>
+  );
+}

--- a/front-pastelero/pages/index.jsx
+++ b/front-pastelero/pages/index.jsx
@@ -3,9 +3,19 @@ import WebFooter from "@/src/components/WebFooter";
 import Link from "next/link";
 import NavbarAdmin from "@/src/components/navbar";
 import { Sofia as SofiaFont, Nunito as NunitoFont } from "next/font/google";
+import { useEffect, useState } from "react";
 
 const sofia  = SofiaFont({ subsets: ["latin"], weight: ["400"] });
 const nunito = NunitoFont({ subsets: ["latin"], weight: ["400", "600", "700", "800"] });
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+// Defaults — usados mientras carga el fetch o si el back falla.
+const HOME_CFG_DEFAULTS = {
+  imagenHeroUrl: "",
+  favoritoSemanaHref: "/enduser/galletas-ny",
+  nuevoSaborHref:     "/enduser/galletas-ny",
+};
 
 /* ─── Categories ─────────────────────────────────────────────────── */
 const CATS = [
@@ -31,6 +41,31 @@ const TESTS = [
 ];
 
 export default function Home() {
+  // Carga la config editable desde el back. Si falla, dejamos defaults
+  // (galletas NY) — el home nunca debe romper por una llamada al back.
+  const [homeCfg, setHomeCfg] = useState(HOME_CFG_DEFAULTS);
+  useEffect(() => {
+    if (!API_BASE) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API_BASE}/home-config`);
+        if (!r.ok) return;
+        const j = await r.json();
+        if (!cancelled && j?.data) {
+          setHomeCfg({
+            imagenHeroUrl:      j.data.imagenHeroUrl || "",
+            favoritoSemanaHref: j.data.favoritoSemanaHref || HOME_CFG_DEFAULTS.favoritoSemanaHref,
+            nuevoSaborHref:     j.data.nuevoSaborHref     || HOME_CFG_DEFAULTS.nuevoSaborHref,
+          });
+        }
+      } catch {
+        /* silencioso — usamos defaults */
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
   return (
     <div className={nunito.className} style={{ minHeight: "100vh", background: "var(--bg-sunken)" }}>
       {/* ── keyframe animations ──────────────────────────── */}
@@ -122,7 +157,15 @@ export default function Home() {
             {/* Cake blob */}
             <div style={{ position: "absolute", inset: "10%", background: "var(--crema)", borderRadius: "50% 50% 50% 50%/50% 50% 50% 50%", display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "var(--shadow-xl)", overflow: "hidden" }}>
               <div aria-hidden="true" className="ru-pattern-sprinkle absolute inset-0" style={{ opacity: 0.2 }} />
-              <span style={{ fontSize: "6rem", position: "relative" }}>🎂</span>
+              {homeCfg.imagenHeroUrl ? (
+                <img
+                  src={homeCfg.imagenHeroUrl}
+                  alt=""
+                  style={{ position: "relative", maxWidth: "80%", maxHeight: "80%", objectFit: "contain" }}
+                />
+              ) : (
+                <span style={{ fontSize: "6rem", position: "relative" }}>🎂</span>
+              )}
             </div>
 
             {/* Floating sprinkle particles */}
@@ -136,18 +179,22 @@ export default function Home() {
             ))}
 
             {/* Floating chips */}
-            <div style={{ position:"absolute", top:"8%", right:"-4%", background:"var(--bg-raised)", padding:"10px 14px", borderRadius:"var(--r-pill)", boxShadow:"var(--shadow-md)", display:"flex", alignItems:"center", gap:10, fontWeight:700, fontSize:"0.8rem", animation:"bob 4s ease-in-out infinite", whiteSpace:"nowrap" }}>
-              <span style={{ width:32, height:32, borderRadius:"50%", background:"#FFE2E7", display:"flex", alignItems:"center", justifyContent:"center", fontSize:16 }}>❤︎</span>
-              <div><div style={{ fontSize:"0.65rem", color:"var(--text-muted)", fontWeight:500 }}>Favorito de</div><div>la semana</div></div>
-            </div>
+            <Link href={homeCfg.favoritoSemanaHref} style={{ textDecoration: "none", color: "inherit" }}>
+              <div style={{ position:"absolute", top:"8%", right:"-4%", background:"var(--bg-raised)", padding:"10px 14px", borderRadius:"var(--r-pill)", boxShadow:"var(--shadow-md)", display:"flex", alignItems:"center", gap:10, fontWeight:700, fontSize:"0.8rem", animation:"bob 4s ease-in-out infinite", whiteSpace:"nowrap", cursor:"pointer" }}>
+                <span style={{ width:32, height:32, borderRadius:"50%", background:"#FFE2E7", display:"flex", alignItems:"center", justifyContent:"center", fontSize:16 }}>❤︎</span>
+                <div><div style={{ fontSize:"0.65rem", color:"var(--text-muted)", fontWeight:500 }}>Favorito de</div><div>la semana</div></div>
+              </div>
+            </Link>
             <div style={{ position:"absolute", bottom:"12%", left:"-6%", background:"var(--bg-raised)", padding:"10px 14px", borderRadius:"var(--r-pill)", boxShadow:"var(--shadow-md)", display:"flex", alignItems:"center", gap:10, fontWeight:700, fontSize:"0.8rem", animation:"bob 4s ease-in-out infinite", animationDelay:"-2s", whiteSpace:"nowrap" }}>
               <span style={{ width:32, height:32, borderRadius:"50%", background:"#B8E6D3", color:"#1D5A45", display:"flex", alignItems:"center", justifyContent:"center", fontSize:16 }}>✓</span>
               <div><div style={{ fontSize:"0.65rem", color:"var(--text-muted)", fontWeight:500 }}>Hecho con</div><div>mantequilla real</div></div>
             </div>
-            <div style={{ position:"absolute", bottom:"40%", right:"-10%", background:"var(--bg-raised)", padding:"10px 14px", borderRadius:"var(--r-pill)", boxShadow:"var(--shadow-md)", display:"flex", alignItems:"center", gap:10, fontWeight:700, fontSize:"0.8rem", animation:"bob 4s ease-in-out infinite", animationDelay:"-1s", whiteSpace:"nowrap" }}>
-              <span style={{ width:32, height:32, borderRadius:"50%", background:"#FFE99B", color:"#6B4F1A", display:"flex", alignItems:"center", justifyContent:"center", fontSize:16 }}>✦</span>
-              <div>Nuevo sabor</div>
-            </div>
+            <Link href={homeCfg.nuevoSaborHref} style={{ textDecoration: "none", color: "inherit" }}>
+              <div style={{ position:"absolute", bottom:"40%", right:"-10%", background:"var(--bg-raised)", padding:"10px 14px", borderRadius:"var(--r-pill)", boxShadow:"var(--shadow-md)", display:"flex", alignItems:"center", gap:10, fontWeight:700, fontSize:"0.8rem", animation:"bob 4s ease-in-out infinite", animationDelay:"-1s", whiteSpace:"nowrap", cursor:"pointer" }}>
+                <span style={{ width:32, height:32, borderRadius:"50%", background:"#FFE99B", color:"#6B4F1A", display:"flex", alignItems:"center", justifyContent:"center", fontSize:16 }}>✦</span>
+                <div>Nuevo sabor</div>
+              </div>
+            </Link>
           </div>
         </div>
       </section>

--- a/front-pastelero/src/components/asideadmin.jsx
+++ b/front-pastelero/src/components/asideadmin.jsx
@@ -122,6 +122,15 @@ const NAV_GROUPS = [
           </svg>
         ),
       },
+      {
+        href: "/dashboard/home-config",
+        label: "Home",
+        icon: (
+          <svg width="18" height="18" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M10 2 1 9h2v8h5v-5h4v5h5V9h2L10 2Z" />
+          </svg>
+        ),
+      },
     ],
   },
 ];


### PR DESCRIPTION
## Resumen

Frontend del feature \"editar el home desde el dashboard\". Va con [BackPastelero#73](https://github.com/mipasteleria/BackPastelero/pull/73).

### Editor admin: \`/dashboard/home-config\`
Nuevo entry en el aside (Configuración → Home). Permite:
- **Imagen del hero**: subir PNG sin fondo (también acepta WEBP/JPG). Reusa \`POST /upload\` existente, después guarda la URL via \`PUT /home-config\`. Preview en vivo + botón \"Quitar imagen\" para volver al emoji.
- **Favorito de la semana**: URL destino del chip. Input text + chips de sugerencias rápidas (Galletas NY, Pastel Vintage, Cotización, Cursos).
- **Nuevo sabor**: igual que el anterior.

### \`pages/index.jsx\` consume la config
- \`useEffect\` fetch al cargar; defaults razonables si el back falla (\"el home nunca debe romper por una llamada al back\").
- Si hay \`imagenHeroUrl\`, se pinta en lugar del emoji 🎂 (objectFit contain, max 80%).
- Los 2 chips animados quedan envueltos en \`<Link>\` con el href configurado.
- El chip \"Hecho con mantequilla real\" queda intacto (es atributo del negocio, no editable).

## Test plan
- [ ] Login como admin, abrir \`/dashboard/home-config\` → se carga config actual.
- [ ] Subir un PNG → la imagen aparece en el preview Y en el home (recargar /).
- [ ] \"Quitar imagen\" → en el home vuelve a aparecer el emoji 🎂.
- [ ] Cambiar URL del Favorito a \`/enduser/pastel-vintage\`, click en el chip del home → navega a Pastel Vintage.
- [ ] Como user no-admin, intentar entrar a \`/dashboard/home-config\` → debe bloquear (back rechaza el PUT con 403; el GET es público).
- [ ] Sin conexión / API caída: el home debe seguir cargando con defaults (emoji + chips a \`/enduser/galletas-ny\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)