### PR TITLE
fix(home-hero): imagen no se corta + animación bob

### DIFF
--- a/front-pastelero/pages/index.jsx
+++ b/front-pastelero/pages/index.jsx
@@ -161,10 +161,13 @@ export default function Home() {
                 <img
                   src={homeCfg.imagenHeroUrl}
                   alt=""
-                  style={{ position: "relative", maxWidth: "80%", maxHeight: "80%", objectFit: "contain" }}
+                  // width/height explícitos (no maxWidth/maxHeight) porque en
+                  // flexbox el <img> a veces ignora los max-* si tiene tamaño
+                  // intrínseco mayor que el contenedor → se ve cortado.
+                  style={{ position: "relative", width: "80%", height: "80%", objectFit: "contain", animation: "bob 4s ease-in-out infinite" }}
                 />
               ) : (
-                <span style={{ fontSize: "6rem", position: "relative" }}>🎂</span>
+                <span style={{ fontSize: "6rem", position: "relative", animation: "bob 4s ease-in-out infinite" }}>🎂</span>
               )}
             </div>
 


### PR DESCRIPTION
Dos issues reportados después del deploy del editor de home:

1. **Imagen cortada por abajo** — \`maxWidth/maxHeight: 80%\` no se respeta en flexbox cuando el \`<img>\` tiene tamaño intrínseco mayor. Cambio a \`width/height: 80%\` + \`objectFit: contain\`: la imagen siempre cabe entera proporcionalmente.
2. **Falta animación** — Agrego \`animation: bob 4s ease-in-out infinite\` (el keyframe ya existía y se usa en la sección Vintage CTA del mismo home).

Aplica tanto a la imagen como al emoji 🎂 fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)