### PR TITLE
fix(home-hero): imagen al 65% para que no se corte con bob

### DIFF
--- a/front-pastelero/pages/index.jsx
+++ b/front-pastelero/pages/index.jsx
@@ -161,10 +161,11 @@ export default function Home() {
                 <img
                   src={homeCfg.imagenHeroUrl}
                   alt=""
-                  // width/height explícitos (no maxWidth/maxHeight) porque en
-                  // flexbox el <img> a veces ignora los max-* si tiene tamaño
-                  // intrínseco mayor que el contenedor → se ve cortado.
-                  style={{ position: "relative", width: "80%", height: "80%", objectFit: "contain", animation: "bob 4s ease-in-out infinite" }}
+                  // 65% (no 80%) porque la imagen es un rectángulo y el contenedor
+                  // es un círculo: a 80% las esquinas del rectángulo quedaban fuera
+                  // del círculo y la animación bob las cortaba. 65% deja margen
+                  // visible para que cualquier PNG se vea completo y "flotando".
+                  style={{ position: "relative", width: "65%", height: "65%", objectFit: "contain", animation: "bob 4s ease-in-out infinite" }}
                 />
               ) : (
                 <span style={{ fontSize: "6rem", position: "relative", animation: "bob 4s ease-in-out infinite" }}>🎂</span>


### PR DESCRIPTION
Continuación del PR #143. A 80% las esquinas del rectángulo de la imagen quedaban justo al borde del círculo (overflow:hidden + borderRadius:50%); la animación bob (translateY -9px) las cortaba — típicamente la base del pastel desaparecía por abajo. Con 65% queda margen claro y cualquier PNG se ve completo flotando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)