### PR TITLE
fix(home-config admin): preview con background-image

### DIFF
--- a/front-pastelero/pages/dashboard/home-config.jsx
+++ b/front-pastelero/pages/dashboard/home-config.jsx
@@ -175,7 +175,22 @@ export default function HomeConfig() {
                     }}
                   >
                     {cfg.imagenHeroUrl ? (
-                      <img src={cfg.imagenHeroUrl} alt="Imagen del hero" style={{ maxWidth: "85%", maxHeight: "85%", objectFit: "contain" }} />
+                      // Mismo approach que en pages/index.jsx: <div> con
+                      // background-image en lugar de <img>, para evitar el
+                      // bug donde Tailwind preflight (`img { height: auto }`)
+                      // ignora el maxHeight y la imagen se ve cortada.
+                      <div
+                        role="img"
+                        aria-label="Imagen del hero"
+                        style={{
+                          width: "80%",
+                          height: "80%",
+                          backgroundImage: `url(${cfg.imagenHeroUrl})`,
+                          backgroundSize: "contain",
+                          backgroundRepeat: "no-repeat",
+                          backgroundPosition: "center",
+                        }}
+                      />
                     ) : (
                       <span style={{ fontSize: "4rem" }}>🎂</span>
                     )}


### PR DESCRIPTION
El preview del editor /dashboard/home-config sufría el mismo bug que ya arreglamos en el home (#145): `<img>` con `maxHeight` se ve cortado porque Tailwind preflight aplica `img { height: auto }` y rompe el max-* inline.

Aplico el mismo fix consistente: `<div role="img">` con `background-image` + `background-size: contain`. El archivo PNG en GCS está intacto, era solo el render del `<img>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)