### PR TITLE
feat(postres): Fase 3 — catálogo público + destacados en home

### DIFF
--- a/front-pastelero/pages/enduser/postres/[slug].jsx
+++ b/front-pastelero/pages/enduser/postres/[slug].jsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import Swal from "sweetalert2";
+import NavbarAdmin from "@/src/components/navbar";
+import WebFooter from "@/src/components/WebFooter";
+import { Sofia as SofiaFont, Nunito as NunitoFont } from "next/font/google";
+
+const sofia  = SofiaFont({ subsets: ["latin"], weight: ["400"] });
+const nunito = NunitoFont({ subsets: ["latin"], weight: ["400", "600", "700", "800"] });
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export default function PostreDetalle() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const [postre, setPostre] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API_BASE}/postres/${slug}`);
+        if (r.status === 404) {
+          if (!cancelled) setNotFound(true);
+          return;
+        }
+        const j = await r.json();
+        if (!cancelled) setPostre(j?.data || null);
+      } catch {
+        /* silencioso */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [slug]);
+
+  /* ── Placeholder para "Agregar al carrito" (Fase 4) ── */
+  const agregarAlCarrito = () => {
+    Swal.fire({
+      icon: "info",
+      title: "¡Pronto disponible!",
+      html: `El sistema de carrito online para postres estará activo muy pronto.<br/><br/>Por ahora, escríbenos para coordinar tu pedido.`,
+      confirmButtonText: "Entendido",
+      background: "#fff1f2",
+      color: "#540027",
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className={nunito.className} style={{ minHeight: "100vh", background: "var(--bg-sunken)" }}>
+        <NavbarAdmin />
+        <p style={{ padding: "8rem 1.5rem", textAlign: "center", color: "var(--text-muted)" }}>Cargando…</p>
+      </div>
+    );
+  }
+
+  if (notFound || !postre) {
+    return (
+      <div className={nunito.className} style={{ minHeight: "100vh", background: "var(--bg-sunken)" }}>
+        <NavbarAdmin />
+        <section style={{ padding: "8rem 1.5rem 4rem", textAlign: "center" }}>
+          <h1 className={sofia.className} style={{ fontSize: "3rem", color: "var(--burdeos)", marginBottom: "1rem" }}>
+            Postre no encontrado
+          </h1>
+          <p style={{ color: "var(--text-soft)", marginBottom: "2rem" }}>
+            El postre que buscas no existe o fue retirado del catálogo.
+          </p>
+          <Link href="/enduser/postres">
+            <button style={{ padding: "12px 28px", borderRadius: "var(--r-pill)", background: "var(--burdeos)", color: "#fff", border: "none", fontWeight: 700, cursor: "pointer", fontFamily: "var(--font-nunito)" }}>
+              Ver todos los postres
+            </button>
+          </Link>
+        </section>
+        <WebFooter />
+      </div>
+    );
+  }
+
+  return (
+    <div className={nunito.className} style={{ minHeight: "100vh", background: "var(--bg-sunken)" }}>
+      <style>{`
+        @media (max-width: 800px) {
+          .detalle-grid { grid-template-columns: 1fr !important; }
+        }
+      `}</style>
+
+      <NavbarAdmin />
+
+      {/* Breadcrumb */}
+      <div style={{ padding: "5rem 1.5rem 0", maxWidth: 1200, margin: "0 auto" }}>
+        <Link href="/enduser/postres" style={{ fontSize: "0.85rem", color: "var(--burdeos)", textDecoration: "none", fontWeight: 700 }}>
+          ← Volver al catálogo
+        </Link>
+      </div>
+
+      <section style={{ padding: "2rem 1.5rem 4rem", maxWidth: 1200, margin: "0 auto" }}>
+        <div className="detalle-grid" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "3rem", alignItems: "center" }}>
+          {/* Imagen */}
+          <div style={{
+            aspectRatio: "1/1",
+            background: "var(--crema)",
+            borderRadius: "var(--r-2xl)",
+            boxShadow: "var(--shadow-lg)",
+            overflow: "hidden",
+            position: "relative",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}>
+            {postre.imagenUrl ? (
+              <div
+                role="img"
+                aria-label={postre.nombre}
+                style={{
+                  width: "85%",
+                  height: "85%",
+                  backgroundImage: `url(${postre.imagenUrl})`,
+                  backgroundSize: "contain",
+                  backgroundRepeat: "no-repeat",
+                  backgroundPosition: "center",
+                }}
+              />
+            ) : (
+              <span style={{ fontSize: "10rem" }}>🎂</span>
+            )}
+          </div>
+
+          {/* Info */}
+          <div>
+            <p style={{ fontSize: "0.7rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.14em", color: "var(--rosa)", marginBottom: 8 }}>
+              Pastelería El Ruiseñor
+            </p>
+            <h1 className={sofia.className} style={{ fontSize: "clamp(2.5rem,5vw,4rem)", color: "var(--burdeos)", lineHeight: 1, marginBottom: "1rem" }}>
+              {postre.nombre}
+            </h1>
+
+            <p className={sofia.className} style={{ fontSize: "3rem", color: "var(--rosa)", lineHeight: 1, marginBottom: "1.5rem" }}>
+              ${Number(postre.precio).toFixed(0)}
+              <span style={{ fontSize: "1rem", color: "var(--text-muted)", marginLeft: 8 }}>MXN</span>
+            </p>
+
+            {postre.descripcion && (
+              <p style={{ fontSize: "1rem", color: "var(--text-soft)", lineHeight: 1.7, marginBottom: "2rem", whiteSpace: "pre-line" }}>
+                {postre.descripcion}
+              </p>
+            )}
+
+            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+              <button
+                onClick={agregarAlCarrito}
+                style={{
+                  padding: "14px 30px",
+                  borderRadius: "var(--r-pill)",
+                  background: "var(--burdeos)",
+                  color: "#fff",
+                  border: "none",
+                  fontWeight: 800,
+                  fontSize: "0.95rem",
+                  cursor: "pointer",
+                  boxShadow: "var(--shadow-sm)",
+                  fontFamily: "var(--font-nunito)",
+                }}
+              >
+                Agregar al carrito
+              </button>
+              <Link href="/enduser/postres">
+                <button style={{
+                  padding: "14px 28px",
+                  borderRadius: "var(--r-pill)",
+                  background: "transparent",
+                  color: "var(--burdeos)",
+                  border: "2px solid var(--border-strong)",
+                  fontWeight: 700,
+                  fontSize: "0.95rem",
+                  cursor: "pointer",
+                  fontFamily: "var(--font-nunito)",
+                }}>
+                  Ver más postres
+                </button>
+              </Link>
+            </div>
+
+            <p style={{ fontSize: "0.78rem", color: "var(--text-muted)", marginTop: "1.5rem" }}>
+              Horneado bajo pedido en Guadalajara · Mínimo 2 días hábiles de anticipación.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <WebFooter />
+    </div>
+  );
+}

--- a/front-pastelero/pages/enduser/postres/index.jsx
+++ b/front-pastelero/pages/enduser/postres/index.jsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import NavbarAdmin from "@/src/components/navbar";
+import WebFooter from "@/src/components/WebFooter";
+import { Sofia as SofiaFont, Nunito as NunitoFont } from "next/font/google";
+
+const sofia  = SofiaFont({ subsets: ["latin"], weight: ["400"] });
+const nunito = NunitoFont({ subsets: ["latin"], weight: ["400", "600", "700", "800"] });
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export default function PostresIndex() {
+  const [postres, setPostres] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${API_BASE}/postres`);
+        const j = await r.json();
+        if (!cancelled) setPostres(j?.data || []);
+      } catch {
+        /* silencioso */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div className={nunito.className} style={{ minHeight: "100vh", background: "var(--bg-sunken)" }}>
+      <style>{`
+        .postre-card:hover { transform: translateY(-6px); box-shadow: 0 16px 36px rgba(84,0,39,.16); }
+        @media (max-width: 900px) { .postres-grid { grid-template-columns: repeat(2,1fr) !important; } }
+        @media (max-width: 520px) { .postres-grid { grid-template-columns: 1fr !important; } }
+      `}</style>
+
+      <NavbarAdmin />
+
+      <section style={{ padding: "5rem 1.5rem 2.5rem", textAlign: "center" }}>
+        <p style={{ fontSize: "0.7rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.14em", color: "var(--rosa)", marginBottom: 8 }}>
+          Catálogo
+        </p>
+        <h1 className={sofia.className} style={{ fontSize: "clamp(2.5rem,5vw,4.5rem)", color: "var(--burdeos)", lineHeight: 1 }}>
+          Top postres
+        </h1>
+        <p style={{ fontSize: "1rem", color: "var(--text-soft)", maxWidth: "60ch", margin: "1rem auto 0", lineHeight: 1.6 }}>
+          Nuestros postres horneados a pedido en Guadalajara. Precio fijo, ingredientes de temporada.
+        </p>
+      </section>
+
+      <section style={{ padding: "1rem 1.5rem 4.5rem", maxWidth: 1200, margin: "0 auto" }}>
+        {loading ? (
+          <p style={{ textAlign: "center", color: "var(--text-muted)" }}>Cargando…</p>
+        ) : postres.length === 0 ? (
+          <div style={{
+            border: "1px dashed var(--border-strong)",
+            borderRadius: "var(--r-xl)",
+            padding: "3rem 1.5rem",
+            textAlign: "center",
+            color: "var(--text-muted)",
+            background: "var(--bg-raised)",
+          }}>
+            <p style={{ fontSize: "1.1rem", marginBottom: 8 }}>Aún no hay postres en el catálogo.</p>
+            <p style={{ fontSize: "0.85rem" }}>
+              Vuelve pronto o explora{" "}
+              <Link href="/enduser/galletas-ny" style={{ color: "var(--burdeos)", fontWeight: 700 }}>nuestras galletas NY</Link>.
+            </p>
+          </div>
+        ) : (
+          <div
+            className="postres-grid"
+            style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: "1rem" }}
+          >
+            {postres.map((p) => (
+              <Link key={p._id} href={`/enduser/postres/${p.slug}`} style={{ textDecoration: "none", color: "inherit" }}>
+                <div
+                  className="postre-card"
+                  style={{
+                    background: "var(--bg-raised)",
+                    borderRadius: "var(--r-xl)",
+                    overflow: "hidden",
+                    boxShadow: "var(--shadow-sm)",
+                    transition: "all 280ms cubic-bezier(.2,.8,.2,1)",
+                    cursor: "pointer",
+                    height: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <div
+                    style={{
+                      aspectRatio: "1/1",
+                      background: p.imagenUrl
+                        ? `var(--crema)`
+                        : "linear-gradient(135deg,#FFE2E7,#FFC3C9)",
+                      backgroundImage: p.imagenUrl ? `url(${p.imagenUrl})` : "none",
+                      backgroundSize: "contain",
+                      backgroundRepeat: "no-repeat",
+                      backgroundPosition: "center",
+                    }}
+                  >
+                    {!p.imagenUrl && (
+                      <div style={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "4rem" }}>
+                        🎂
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ padding: "1rem 1.25rem 1.25rem", flexGrow: 1, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+                    <div>
+                      <h3 style={{ fontWeight: 700, fontSize: "1.05rem", marginBottom: 4, color: "var(--color-text)" }}>{p.nombre}</h3>
+                      {p.descripcion && (
+                        <p style={{ fontSize: "0.78rem", color: "var(--text-muted)", marginBottom: "0.75rem", lineHeight: 1.4, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+                          {p.descripcion}
+                        </p>
+                      )}
+                    </div>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 8 }}>
+                      <span className={sofia.className} style={{ fontSize: "1.75rem", color: "var(--rosa)", lineHeight: 1 }}>${Number(p.precio).toFixed(0)}</span>
+                      <span style={{ fontSize: "0.78rem", fontWeight: 700, color: "var(--burdeos)" }}>Ver →</span>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <WebFooter />
+    </div>
+  );
+}

--- a/front-pastelero/pages/index.jsx
+++ b/front-pastelero/pages/index.jsx
@@ -44,6 +44,9 @@ export default function Home() {
   // Carga la config editable desde el back. Si falla, dejamos defaults
   // (galletas NY) — el home nunca debe romper por una llamada al back.
   const [homeCfg, setHomeCfg] = useState(HOME_CFG_DEFAULTS);
+  // Postres destacados marcados por el admin. Si el admin aún no marcó
+  // ninguno (o la API falla), caemos al BEST hardcoded como fallback.
+  const [destacados, setDestacados] = useState(null); // null = cargando
   useEffect(() => {
     if (!API_BASE) return;
     let cancelled = false;
@@ -63,8 +66,35 @@ export default function Home() {
         /* silencioso — usamos defaults */
       }
     })();
+    (async () => {
+      try {
+        const r = await fetch(`${API_BASE}/postres/destacados`);
+        if (!r.ok) { if (!cancelled) setDestacados([]); return; }
+        const j = await r.json();
+        if (!cancelled) setDestacados(j?.data || []);
+      } catch {
+        if (!cancelled) setDestacados([]);
+      }
+    })();
     return () => { cancelled = true; };
   }, []);
+
+  // Mapear destacados al shape del BEST hardcoded para que el render sea uno solo.
+  // Si no hay destacados o la API aún no respondió, usar el BEST como fallback.
+  const mostrarItems = (destacados && destacados.length > 0)
+    ? destacados.map((p) => ({
+        label: p.nombre,
+        sub: p.descripcion
+          ? (p.descripcion.length > 40 ? p.descripcion.slice(0, 40) + "…" : p.descripcion)
+          : "",
+        price: `$${Number(p.precio).toFixed(0)}`,
+        href: `/enduser/postres/${p.slug}`,
+        imagenUrl: p.imagenUrl || "",
+        bg: "linear-gradient(135deg,#FFE2E7,#FFC3C9)",
+        emoji: "🎂",
+        tag: null,
+      }))
+    : BEST;
 
   return (
     <div className={nunito.className} style={{ minHeight: "100vh", background: "var(--bg-sunken)" }}>
@@ -259,8 +289,8 @@ export default function Home() {
         </div>
 
         <div className="best-grid" style={{ maxWidth: 1200, margin: "0 auto", display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: "1rem" }}>
-          {BEST.map((p) => (
-            <Link key={p.label} href={p.href} style={{ textDecoration: "none" }}>
+          {mostrarItems.map((p, idx) => (
+            <Link key={p.href || idx} href={p.href} style={{ textDecoration: "none" }}>
               <div className="prod-card" style={{ background: "var(--bg-raised)", borderRadius: "var(--r-xl)", overflow: "hidden", boxShadow: "var(--shadow-sm)", transition: "all 280ms cubic-bezier(.2,.8,.2,1)", position: "relative", cursor: "pointer" }}>
                 {/* Badge */}
                 {p.tag && (
@@ -270,10 +300,26 @@ export default function Home() {
                 )}
                 {/* Heart */}
                 <button aria-label="favorito" style={{ position: "absolute", top: 10, right: 10, zIndex: 2, width: 36, height: 36, borderRadius: "50%", background: "rgba(255,255,255,.9)", backdropFilter: "blur(6px)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--rosa)", fontSize: 18, cursor: "pointer" }}>♥</button>
-                {/* Product image area */}
-                <div style={{ aspectRatio: "1/1", background: p.bg, display: "flex", alignItems: "center", justifyContent: "center", position: "relative", overflow: "hidden" }}>
-                  <div aria-hidden="true" className="ru-pattern-sprinkle absolute inset-0" style={{ opacity: 0.3 }} />
-                  <span style={{ fontSize: "5rem", position: "relative", zIndex: 1 }}>{p.emoji}</span>
+                {/* Product image area: imagen del postre si existe, sino emoji con gradiente */}
+                <div style={{
+                  aspectRatio: "1/1",
+                  background: p.imagenUrl ? "var(--crema)" : p.bg,
+                  backgroundImage: p.imagenUrl ? `url(${p.imagenUrl})` : "none",
+                  backgroundSize: "contain",
+                  backgroundRepeat: "no-repeat",
+                  backgroundPosition: "center",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  position: "relative",
+                  overflow: "hidden",
+                }}>
+                  {!p.imagenUrl && (
+                    <>
+                      <div aria-hidden="true" className="ru-pattern-sprinkle absolute inset-0" style={{ opacity: 0.3 }} />
+                      <span style={{ fontSize: "5rem", position: "relative", zIndex: 1 }}>{p.emoji}</span>
+                    </>
+                  )}
                 </div>
                 {/* Body */}
                 <div style={{ padding: "1rem 1.25rem 1.25rem" }}>
@@ -290,7 +336,7 @@ export default function Home() {
         </div>
 
         <div style={{ textAlign: "center", marginTop: "2.5rem" }}>
-          <Link href="/enduser/conocenuestrosproductos">
+          <Link href="/enduser/postres">
             <button className="link-btn" style={{ padding: "12px 36px", borderRadius: "var(--r-pill)", border: "1.5px solid var(--border-strong)", background: "transparent", color: "var(--burdeos)", cursor: "pointer", fontWeight: 700, fontFamily: "var(--font-nunito)", fontSize: "0.9rem", transition: "all 150ms" }}>
               Ver todo el catálogo
             </button>


### PR DESCRIPTION
Fase 3 de 4. Páginas públicas del catálogo y reemplazo del bloque hardcoded en el home.

## Páginas nuevas
- `/enduser/postres` — grid con todos los postres activos (responsive: 4/2/1 columnas).
- `/enduser/postres/[slug]` — detalle con imagen grande, descripción, precio y CTA.

## Home actualizado (`pages/index.jsx`)
- La sección **"Los más horneados"** ahora carga `/postres/destacados` y muestra los 4 marcados por el admin.
- **Fallback al BEST hardcoded** si no hay destacados o la API falla → el home nunca se ve vacío.
- Cards soportan tanto imagen real (background-image) como emoji+gradiente del fallback.
- Botón "Ver todo el catálogo" → `/enduser/postres` (antes iba a página obsoleta).

## Botón "Agregar al carrito" en el detalle
Por ahora es **placeholder**: muestra un Swal explicando que el carrito online estará disponible pronto. Se conecta de verdad en Fase 4. Esto le permite a Alberto enseñar el catálogo sin que parezca a medias.

## Test plan
- [ ] Visitar `/enduser/postres` sin postres dados de alta → mensaje invitando a galletas NY.
- [ ] Crear un postre activo en `/dashboard/postres` → aparece en `/enduser/postres`.
- [ ] Click en una card → detalle por slug carga con imagen, descripción y precio.
- [ ] Click "Agregar al carrito" en el detalle → Swal de "Próximamente".
- [ ] Marcar 1+ postre como destacado → aparece en "Los más horneados" del home (Ctrl+Shift+R).
- [ ] Quitar todos los destacados → home vuelve a mostrar el BEST hardcoded.

## Próxima fase (la grande)
**Fase 4**: carrito unificado postres+galletas, checkout Stripe Embedded, emails de confirmación, Calendar event, notas internas admin. Aquí decidimos cómo se ve el carrito unificado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)