### PR TITLE
fix(recetas): auto-llenar precio y unidad desde catálogo de insumos

### DIFF
--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -20,6 +20,7 @@ export default function EditarReceta() {
     control,
     getValues,
     setValue,
+    watch,
     formState: { errors },
   } = useForm();
   const [ingredientsList, setIngredientsList] = useState([]);
@@ -290,26 +291,61 @@ const handleDeleteIngredient = (index) => {
                     />
                   </div>
                   {renderInput("cantidad", "Cantidad", "number", "0.0", "")}
-                  {renderInput("precio", "Precio", "number", "0.0", "")}
-                  <div className="flex items-end">
-                  <div className="w-full">
-                      <label htmlFor="unidad" className="block mb-2 text-sm font-medium dark:text-white">Unidad</label>
-                      <Controller
-                        name="unidad"
-                        control={control}
-                        defaultValue="gramos"
-                        render={({ field }) => (
-                          <select
-                            id="unidad"
-                            className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5 dark:placeholder-secondary dark:focus:ring-blue-500 dark:focus:border-accent"
-                            {...field}
-                          >
-                            <option value="gramos">gramos</option>
-                            <option value="ml">mililitros</option>
-                          </select>
-                        )}
-                      />
+
+                  {/* Precio: auto-calculado desde el catálogo si hay
+                      ingrediente seleccionado con cost+amount. */}
+                  {selectedIngredient && selectedIngredient.cost && selectedIngredient.amount ? (
+                    <div className="w-full">
+                      <label className="block text-sm font-medium dark:text-white">Precio calculado</label>
+                      <div className="bg-gray-50 border border-secondary text-sm rounded-lg p-2.5 text-gray-700">
+                        <span className="font-bold">
+                          ${((selectedIngredient.cost / selectedIngredient.amount) * (parseFloat(watch("cantidad")) || 0)).toFixed(2)}
+                        </span>
+                        <span className="text-xs text-gray-500 ml-2">
+                          (${selectedIngredient.cost}/{selectedIngredient.amount}{selectedIngredient.unit} × cantidad)
+                        </span>
+                      </div>
                     </div>
+                  ) : selectedIngredient && (!selectedIngredient.cost || !selectedIngredient.amount) ? (
+                    <>
+                      <p className="text-xs text-orange-700 bg-orange-50 border border-orange-200 rounded-lg p-2.5">
+                        Este insumo no tiene precio/cantidad en el catálogo. Edítalo en <Link href="/dashboard/insumosytrabajomanual" className="underline font-bold">Insumos</Link> y vuelve aquí, o ingresa el precio manualmente abajo.
+                      </p>
+                      {renderInput("precio", "Precio manual", "number", "0.0", "")}
+                    </>
+                  ) : (
+                    renderInput("precio", "Precio", "number", "0.0", "")
+                  )}
+
+                  <div className="flex items-end">
+                    {/* Unidad: del catálogo si está seleccionado; si no, select. */}
+                    {selectedIngredient ? (
+                      <div className="w-full">
+                        <label className="block mb-2 text-sm font-medium dark:text-white">Unidad</label>
+                        <div className="bg-gray-50 border border-secondary text-sm rounded-lg p-2.5 text-gray-700">
+                          {selectedIngredient.unit || "—"}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="w-full">
+                        <label htmlFor="unidad" className="block mb-2 text-sm font-medium dark:text-white">Unidad</label>
+                        <Controller
+                          name="unidad"
+                          control={control}
+                          defaultValue="gramos"
+                          render={({ field }) => (
+                            <select
+                              id="unidad"
+                              className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5 dark:placeholder-secondary dark:focus:ring-blue-500 dark:focus:border-accent"
+                              {...field}
+                            >
+                              <option value="gramos">gramos</option>
+                              <option value="ml">mililitros</option>
+                            </select>
+                          )}
+                        />
+                      </div>
+                    )}
                     <button
                       type="button"
                       onClick={handleAddIngredient}

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -18,6 +18,7 @@ export default function NuevaReceta() {
     control,
     getValues,
     setValue,
+    watch,
     formState: { errors } } = useForm();
   const { userToken } = useAuth();
 
@@ -259,27 +260,65 @@ export default function NuevaReceta() {
                     />
                   </div>
                   {renderInput("cantidad", "Cantidad", "number", "0.0", "")}
-                  {renderInput("precio", "Precio", "number", "0.0", "")}
-                  <div 
-                  className="flex items-end">
+
+                  {/* Precio: si hay ingrediente del catálogo, se calcula
+                      automáticamente desde su cost/amount × cantidad.
+                      Sólo se pide manualmente si no hay ingrediente
+                      seleccionado del catálogo (caso legacy). */}
+                  {selectedIngredient && selectedIngredient.cost && selectedIngredient.amount ? (
                     <div className="w-full">
-                      <label htmlFor="unidad" className="block mb-2 text-sm font-medium dark:text-white">Unidad</label>
-                      <Controller
-                        name="unidad"
-                        control={control}
-                        defaultValue="gramos"
-                        render={({ field }) => (
-                          <select
-                            id="unidad"
-                            className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5 dark:placeholder-secondary dark:focus:ring-blue-500 dark:focus:border-accent"
-                            {...field}
-                          >
-                            <option value="gramos">gramos</option>
-                            <option value="ml">mililitros</option>
-                          </select>
-                        )}
-                      />
+                      <label className="block text-sm font-medium dark:text-white">Precio calculado</label>
+                      <div className="bg-gray-50 border border-secondary text-sm rounded-lg p-2.5 text-gray-700">
+                        <span className="font-bold">
+                          ${((selectedIngredient.cost / selectedIngredient.amount) * (parseFloat(watch("cantidad")) || 0)).toFixed(2)}
+                        </span>
+                        <span className="text-xs text-gray-500 ml-2">
+                          (${selectedIngredient.cost}/{selectedIngredient.amount}{selectedIngredient.unit} × cantidad)
+                        </span>
+                      </div>
                     </div>
+                  ) : selectedIngredient && (!selectedIngredient.cost || !selectedIngredient.amount) ? (
+                    <>
+                      <p className="text-xs text-orange-700 bg-orange-50 border border-orange-200 rounded-lg p-2.5">
+                        Este insumo no tiene precio/cantidad en el catálogo. Edítalo en <Link href="/dashboard/insumosytrabajomanual" className="underline font-bold">Insumos</Link> y vuelve aquí, o ingresa el precio manualmente abajo.
+                      </p>
+                      {renderInput("precio", "Precio manual", "number", "0.0", "")}
+                    </>
+                  ) : (
+                    renderInput("precio", "Precio", "number", "0.0", "")
+                  )}
+
+                  <div className="flex items-end">
+                    {/* Unidad: si viene del catálogo, mostrar como texto
+                        (no editable). Si no, dejar el select para
+                        compatibilidad con entrada manual. */}
+                    {selectedIngredient ? (
+                      <div className="w-full">
+                        <label className="block mb-2 text-sm font-medium dark:text-white">Unidad</label>
+                        <div className="bg-gray-50 border border-secondary text-sm rounded-lg p-2.5 text-gray-700">
+                          {selectedIngredient.unit || "—"}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="w-full">
+                        <label htmlFor="unidad" className="block mb-2 text-sm font-medium dark:text-white">Unidad</label>
+                        <Controller
+                          name="unidad"
+                          control={control}
+                          defaultValue="gramos"
+                          render={({ field }) => (
+                            <select
+                              id="unidad"
+                              className="bg-gray-50 border border-secondary text-sm rounded-lg focus:ring-accent focus:border-accent block w-full p-2.5 dark:placeholder-secondary dark:focus:ring-blue-500 dark:focus:border-accent"
+                              {...field}
+                            >
+                              <option value="gramos">gramos</option>
+                              <option value="ml">mililitros</option>
+                            </select>
+                          )}
+                        />
+                      </div>
+                    )}
                     <button
                       type="button"
                       onClick={handleAddIngredient}


### PR DESCRIPTION
Reportado por Alberto en /dashboard/costeorecetas/nuevareceta:

> Al seleccionar un ingrediente desde el dropdown (que viene de la BD), el form me pide ingresar Precio y Unidad manualmente — pero esos datos ya están en el catálogo de insumos. Trabajo redundante.

**Bug oculto adicional:** lo que el admin escribía en "Precio" se IGNORABA en `handleAddIngredient` cuando había insumo seleccionado del catálogo (el precio se calcula como `cost / amount × cantidad`). O sea: trabajo manual + el valor escrito no era el guardado.

## Fix

Con insumo seleccionado del catálogo:
- **Si tiene cost+amount**: muestra `Precio calculado: $X.XX` con cálculo en vivo según cantidad (react-hook-form `watch`). Sin input editable.
- **Si NO tiene cost+amount**: muestra warning naranja con link directo a Insumos para configurarlo + permite ingresar precio manual como fallback.
- **Unidad**: muestra `selectedIngredient.unit` como texto read-only (ya se auto-seteaba pero el select editable era engañoso).

Sin insumo seleccionado (caso edge): vuelve a los inputs editables originales — preserva la compat.

Mismo fix en `nuevareceta.jsx` y `editarreceta/[id].jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)