### PR TITLE
fix(recetas): limpiar form completo al agregar ingrediente

### DIFF
--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -140,8 +140,11 @@ const handleAddIngredient = () => {
   };
 
   setIngredientsList(prev => [...prev, newIngredient]);
+  // Limpiar todos los campos del form para seguir agregando sin borrar a mano.
+  setValue("ingrediente", "");
   setValue("cantidad", "");
   setValue("precio", "");
+  setValue("unidad", "gramos");
   setSelectedIngredient(null);
 };
 

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -96,8 +96,12 @@ export default function NuevaReceta() {
     };
 
     setIngredientsList(prev => [...prev, newIngredient]);
+    // Limpiar todos los campos del form de ingrediente para que el
+    // admin pueda seguir agregando sin tener que borrar manualmente.
+    setValue("ingrediente", "");
     setValue("cantidad", "");
     setValue("precio", "");
+    setValue("unidad", "gramos"); // vuelve al default del select
     setSelectedIngredient(null);
   };
 


### PR DESCRIPTION
El dropdown de Ingrediente y el select de Unidad mantenían el último valor después de agregar — el admin tenía que des-seleccionar manualmente antes del siguiente ingrediente. Ahora limpiamos los 4 campos (ingrediente, cantidad, precio, unidad) + selectedIngredient. Aplica a crear y editar receta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)