### PR TITLE
feat(recetas): botón editar + alineación de tabla de ingredientes

### DIFF
--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -181,7 +181,23 @@ const handleDeleteIngredient = (index) => {
     calculateTotal();
     return newIngredients;
   });
-};  
+};
+
+const handleEditIngredient = (index) => {
+  const ing = ingredientsList[index];
+  if (!ing) return;
+  const insumoCatalogo =
+    ingredientOptions.find(o => o._id === ing.insumoId) ||
+    ingredientOptions.find(o => o.name === ing.ingrediente) ||
+    null;
+  setSelectedIngredient(insumoCatalogo);
+  setValue("ingrediente", ing.ingrediente);
+  setValue("cantidad", ing.cantidad);
+  setValue("precio", ing.precio);
+  setValue("unidad", ing.unidad);
+  setIngredientsList(prev => prev.filter((_, i) => i !== index));
+  window.scrollTo({ top: 0, behavior: "smooth" });
+};
 
   const onInputChange = () => calculateTotal();
 
@@ -402,28 +418,41 @@ const handleDeleteIngredient = (index) => {
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="text-xs text-text uppercase bg-rose-50">
                     <tr>
-                      <th className="px-6 py-3">Ingrediente</th>
-                      <th className="px-6 py-3">Cantidad</th>
-                      <th className="px-6 py-3">Precio</th>
-                      <th className="px-6 py-3">Unidad</th>
-                      <th className="px-6 py-3">Costo por gr/ml</th>
-                      <th className="px-6 py-3">Acciones</th>
+                      <th className="px-6 py-3 text-left">Ingrediente</th>
+                      <th className="px-6 py-3 text-left">Cantidad</th>
+                      <th className="px-6 py-3 text-left">Precio</th>
+                      <th className="px-6 py-3 text-left">Unidad</th>
+                      <th className="px-6 py-3 text-left">Costo por gr/ml</th>
+                      <th className="px-6 py-3 text-center">Acciones</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
                     {ingredientsList.map((ingredient, index) => (
                       <tr key={index}>
-                        <td className="px-6 py-4">{ingredient.ingrediente}</td>
-                        <td className="px-6 py-4">{ingredient.cantidad}</td>
-                        <td className="px-6 py-4">{ingredient.precio}</td>
-                        <td className="px-6 py-4">{ingredient.unidad}</td>
-                        <td className="px-6 py-4">{ingredient.total}</td>
-                        <td className="px-6 py-4">
-                          <button
-                            type="button"
-                            onClick={() => handleDeleteIngredient(index)}
-                            className="text-red-500 hover:text-red-700"
-                          >
+                        <td className="px-6 py-4 text-left">{ingredient.ingrediente}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.cantidad}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.precio}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.unidad}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.total}</td>
+                        <td className="px-6 py-4 text-center">
+                          <div className="flex items-center justify-center gap-3">
+                            <button
+                              type="button"
+                              onClick={() => handleEditIngredient(index)}
+                              title="Editar ingrediente"
+                              style={{ color: "var(--burdeos)" }}
+                              className="hover:opacity-70"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5m-1.414-9.414a2 2 0 1 1 2.828 2.828L11.828 15H9v-2.828l8.586-8.586Z" />
+                              </svg>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleDeleteIngredient(index)}
+                              title="Borrar ingrediente"
+                              className="text-red-500 hover:text-red-700"
+                            >
                             <svg
                               xmlns="http://www.w3.org/2000/svg"
                               className="h-5 w-5"
@@ -438,7 +467,8 @@ const handleDeleteIngredient = (index) => {
                                 d="M6 18L18 6M6 6l12 12"
                               />
                             </svg>
-                          </button>
+                            </button>
+                          </div>
                         </td>
                       </tr>
                     ))}

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -157,7 +157,29 @@ export default function NuevaReceta() {
       calculateTotal();
       return newIngredients;
     });
-  };  
+  };
+
+  /**
+   * Editar un ingrediente: carga sus datos al form (resucitando el
+   * selectedIngredient del catálogo si aplica) y lo retira de la lista.
+   * Cuando el admin edita y vuelve a hacer click en "Agregar", entra
+   * con los valores actualizados.
+   */
+  const handleEditIngredient = (index) => {
+    const ing = ingredientsList[index];
+    if (!ing) return;
+    const insumoCatalogo =
+      ingredientOptions.find(o => o._id === ing.insumoId) ||
+      ingredientOptions.find(o => o.name === ing.ingrediente) ||
+      null;
+    setSelectedIngredient(insumoCatalogo);
+    setValue("ingrediente", ing.ingrediente);
+    setValue("cantidad", ing.cantidad);
+    setValue("precio", ing.precio);
+    setValue("unidad", ing.unidad);
+    setIngredientsList(prev => prev.filter((_, i) => i !== index));
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   const onInputChange = () => calculateTotal();
   
@@ -393,41 +415,46 @@ export default function NuevaReceta() {
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="text-xs text-text uppercase bg-rose-50">
                     <tr>
-                      <th className="px-6 py-3">Ingrediente</th>
-                      <th className="px-6 py-3">Cantidad</th>
-                      <th className="px-6 py-3">Precio</th>
-                      <th className="px-6 py-3">Unidad</th>
-                      <th className="px-6 py-3">Costo</th>
-                      <th className="px-6 py-3">Eliminar</th>
+                      <th className="px-6 py-3 text-left">Ingrediente</th>
+                      <th className="px-6 py-3 text-left">Cantidad</th>
+                      <th className="px-6 py-3 text-left">Precio</th>
+                      <th className="px-6 py-3 text-left">Unidad</th>
+                      <th className="px-6 py-3 text-left">Costo por gr/ml</th>
+                      <th className="px-6 py-3 text-center">Acciones</th>
                     </tr>
                   </thead>
                   <tbody>
                     {ingredientsList.map((ingredient, index) => (
                       <tr key={index} className="bg-white border-b dark:bg-gray-900 dark:border-gray-700">
-                        <td className="px-6 py-4">{ingredient.ingrediente}</td>
-                        <td className="px-6 py-4">{ingredient.cantidad}</td>
-                        <td className="px-6 py-4">{ingredient.precio}</td>
-                        <td className="px-6 py-4">{ingredient.unidad}</td>
-                        <td className="px-6 py-4">{ingredient.total}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.ingrediente}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.cantidad}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.precio}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.unidad}</td>
+                        <td className="px-6 py-4 text-left">{ingredient.total}</td>
                         <td className="px-6 py-4 text-center">
-                          <button
-                            type="button"
-                            onClick={() => handleDeleteIngredient(index)}
-                            className="text-red-600 hover:text-red-800"
-                          >
-                            <svg 
-                            xmlns="http://www.w3.org/2000/svg" 
-                            className="h-5 w-5" 
-                            fill="none" 
-                            viewBox="0 0 24 24" 
-                            stroke="currentColor">
-                              <path 
-                              strokeLinecap="round" 
-                              strokeLinejoin="round" 
-                              strokeWidth="2" 
-                              d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                          </button>
+                          <div className="flex items-center justify-center gap-3">
+                            <button
+                              type="button"
+                              onClick={() => handleEditIngredient(index)}
+                              title="Editar ingrediente"
+                              style={{ color: "var(--burdeos)" }}
+                              className="hover:opacity-70"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5m-1.414-9.414a2 2 0 1 1 2.828 2.828L11.828 15H9v-2.828l8.586-8.586Z" />
+                              </svg>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleDeleteIngredient(index)}
+                              title="Borrar ingrediente"
+                              className="text-red-600 hover:text-red-800"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                              </svg>
+                            </button>
+                          </div>
                         </td>
                       </tr>
                     ))}


### PR DESCRIPTION
Pedido de Alberto:
- **Editar** ingredientes desde la tabla (antes solo se podía borrar y volver a agregar).
- **Alineación** del contenido con los headers de la tabla.

## Cambios
- Botón Editar (lápiz) además del Borrar (X) en la columna Acciones.
- Editar carga los datos del ingrediente al form de arriba (resucitando el `selectedIngredient` del catálogo si aplica) y retira la fila. Scroll automático al form.
- Headers y celdas con `text-left` explícito → contenido alineado con su columna en todos los navegadores.
- Columna Acciones centrada para hospedar los 2 botones.
- En nuevareceta el header decía "Eliminar" → ahora "Acciones" (consistente con editarreceta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)