### PR TITLE
feat(recetas): layout amplio

### DIFF
--- a/front-pastelero/pages/dashboard/costeorecetas/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/[id].jsx
@@ -38,7 +38,7 @@ export default function VerReceta() {
       <div className="flex flex-row mt-16">
         <Asideadmin />
         <main
-          className={`text-text ${poppins.className} flex-grow w-3/4 max-w-screen-lg mx-auto`}
+          className={`text-text ${poppins.className} flex-grow w-full px-4 md:px-8 max-w-screen-2xl mx-auto`}
         >
           <h1 className={`text-4xl p-4 ${sofia.className}`}>Ver Receta</h1>
           <div className="m-4">

--- a/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/editarreceta/[id].jsx
@@ -285,7 +285,7 @@ const handleEditIngredient = (index) => {
       <div className="flex flex-row mt-16">
         <Asideadmin />
         <main
-          className={`text-text ${poppins.className} flex-grow w-3/4 max-w-screen-lg mx-auto`}
+          className={`text-text ${poppins.className} flex-grow w-full px-4 md:px-8 max-w-screen-2xl mx-auto`}
         >
           <h1 className={`text-4xl p-4 ${sofia.className}`}>Editar Receta</h1>
           <form 

--- a/front-pastelero/pages/dashboard/costeorecetas/index.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/index.jsx
@@ -111,7 +111,7 @@ export default function Costeorecetas() {
       <NavbarAdmin className="fixed top-0 w-full z-50" />
       <div className="flex flex-row mt-16">
         <Asideadmin />
-        <main className={`text-text ${poppins.className} flex-grow w-3/4 max-w-screen-lg mx-auto`}>
+        <main className={`text-text ${poppins.className} flex-grow w-full px-4 md:px-8 max-w-screen-2xl mx-auto`}>
           <h1 className={`text-4xl p-4 ${sofia.className}`}>Mis recetas</h1>
           <div className="flex flex-col md:flex-row items-start md:items-center justify-between overflow-x-auto shadow-md rounded-lg p-4 m-4">
             <div className="overflow-x-auto w-full">

--- a/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
+++ b/front-pastelero/pages/dashboard/costeorecetas/nuevareceta.jsx
@@ -288,7 +288,7 @@ export default function NuevaReceta() {
       className="flex flex-row mt-16">
         <Asideadmin />
         <main 
-        className={`text-text ${poppins.className} flex-grow w-3/4 max-w-screen-lg mx-auto`}>
+        className={`text-text ${poppins.className} flex-grow w-full px-4 md:px-8 max-w-screen-2xl mx-auto`}>
           <h1 
           className={`text-4xl p-4 ${sofia.className}`}>Nueva Receta</h1>
           <form 


### PR DESCRIPTION
Mismo cambio que #156: `max-w-screen-lg w-3/4` → `max-w-screen-2xl w-full` con padding lateral responsive. Aplicado a las 4 pantallas de recetas (lista, detalle, nueva, editar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)