### PR TITLE
feat(postres): precio sugerido desde receta + branding + empaque (front)

### DIFF
--- a/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
+++ b/front-pastelero/pages/dashboard/gastosfijosymanodeobra.jsx
@@ -18,6 +18,8 @@ export default function Conocenuestrosproductos() {
     costoBrandingPorGalleta: 0,
     markupGalletasPct: 60,
     margenMinimoGalleta: 5,
+    costoBrandingPorPostre: 0,
+    markupPostresPct: 60,
   });
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
   const { userToken } = useAuth();
@@ -26,6 +28,7 @@ export default function Conocenuestrosproductos() {
   // el de fixedCosts/laborCosts para que el admin pueda guardar uno
   // u otro sin tener que llenar los dos cada vez.
   const galletasForm = useForm();
+  const postresForm  = useForm();
 
   useEffect(() => {
     const fetchCostData = async () => {
@@ -132,6 +135,48 @@ export default function Conocenuestrosproductos() {
       Swal.fire({
         title: 'Error',
         text: 'No se pudo actualizar la configuración de galletas.',
+        icon: 'error',
+        timer: 2000,
+        showConfirmButton: false,
+        background: '#fff1f2',
+        color: '#540027',
+      });
+    }
+  };
+
+  // Mismo patrón que onSubmitGalletas pero para los campos de postres.
+  const onSubmitPostres = async (data) => {
+    try {
+      const response = await fetch(`${API_BASE}/costs`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${userToken}`,
+        },
+        body: JSON.stringify({
+          fixedCosts: costData.fixedCosts,
+          laborCosts: costData.laborCosts,
+          costoBrandingPorPostre: parseFloat(data.costoBrandingPorPostre) || 0,
+          markupPostresPct: parseFloat(data.markupPostresPct) || 0,
+        }),
+      });
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const result = await response.json();
+      setCostData((prev) => ({ ...prev, ...result }));
+      Swal.fire({
+        title: 'Config de Postres actualizada',
+        icon: 'success',
+        timer: 2000,
+        timerProgressBar: true,
+        showConfirmButton: false,
+        background: '#fff1f2',
+        color: '#540027',
+      });
+    } catch (error) {
+      console.error('Error al actualizar config postres:', error);
+      Swal.fire({
+        title: 'Error',
+        text: 'No se pudo actualizar la configuración de postres.',
         icon: 'error',
         timer: 2000,
         showConfirmButton: false,
@@ -282,6 +327,74 @@ export default function Conocenuestrosproductos() {
               <p className="text-md">Branding/empaque: ${costData.costoBrandingPorGalleta ?? 0} MXN/pieza</p>
               <p className="text-md">Markup sugerido: {costData.markupGalletasPct ?? 60}%</p>
               <p className="text-md">Margen mínimo (alerta): ${costData.margenMinimoGalleta ?? 5} MXN</p>
+            </div>
+          </div>
+
+          {/* ── Sección: Configuración de Postres ─────────────────── */}
+          <div className="border-t-2 border-secondary mt-8 pt-6">
+            <h2 className={`text-3xl px-6 ${sofia.className}`} style={{ color: "#540027" }}>
+              🎂 Configuración de Postres
+            </h2>
+            <p className="text-sm px-6 mb-4" style={{ color: "#a78891" }}>
+              El branding es global (mismo costo en todos los postres). El empaque NO va aquí — varía por postre y se ingresa al dar de alta cada uno.
+            </p>
+
+            <form onSubmit={postresForm.handleSubmit(onSubmitPostres)}>
+              <div className="flex flex-col md:flex-row items-center">
+                <p className="font-bold m-4">Costo de branding por postre</p>
+                <div className="m-4">
+                  <label htmlFor="costoBrandingPorPostre" className="block mb-2 text-sm font-medium">
+                    MXN por postre
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    id="costoBrandingPorPostre"
+                    defaultValue={costData.costoBrandingPorPostre ?? 0}
+                    key={`branding-postre-${costData.costoBrandingPorPostre ?? 0}`}
+                    {...postresForm.register("costoBrandingPorPostre", { required: true })}
+                    className="bg-gray-50 border border-secondary text-sm rounded-lg block w-full p-2.5"
+                    placeholder="0.0"
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col md:flex-row items-center">
+                <p className="font-bold m-4">Markup sugerido para postres</p>
+                <div className="m-4">
+                  <label htmlFor="markupPostresPct" className="block mb-2 text-sm font-medium">
+                    Porcentaje (%)
+                  </label>
+                  <input
+                    type="number"
+                    step="1"
+                    min="0"
+                    id="markupPostresPct"
+                    defaultValue={costData.markupPostresPct ?? 60}
+                    key={`markup-postres-${costData.markupPostresPct ?? 60}`}
+                    {...postresForm.register("markupPostresPct", { required: true })}
+                    className="bg-gray-50 border border-secondary text-sm rounded-lg block w-full p-2.5"
+                    placeholder="60"
+                  />
+                  <p className="text-xs mt-1" style={{ color: "#a78891" }}>
+                    Default cuando la receta no tiene margen propio o no se sobrescribe en el form de postre.
+                  </p>
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                className="shadow-md text-text bg-primary hover:bg-accent hover:text-white focus:ring-4 focus:outline-none font-medium rounded-lg text-sm w-96 sm:w-96 px-16 py-2.5 text-center m-4"
+              >
+                Guardar configuración de Postres
+              </button>
+            </form>
+
+            <div className="m-4 p-4 rounded-lg" style={{ background: "#fff1f2" }}>
+              <p className="text-lg font-semibold" style={{ color: "#540027" }}>Config actual de postres:</p>
+              <p className="text-md">Branding por postre: ${costData.costoBrandingPorPostre ?? 0} MXN</p>
+              <p className="text-md">Markup sugerido: {costData.markupPostresPct ?? 60}%</p>
             </div>
           </div>
         </main>

--- a/front-pastelero/pages/dashboard/postres.jsx
+++ b/front-pastelero/pages/dashboard/postres.jsx
@@ -72,15 +72,21 @@ const FORM_VACIO = {
   activo: true,
   destacado: false,
   orden: 0,
+  recetaId: "",
+  costoEmpaque: "",
 };
 
 export default function DashboardPostres() {
   const { userToken } = useAuth();
   const [postres, setPostres] = useState([]);
+  const [recetas, setRecetas] = useState([]);
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState(FORM_VACIO);
   const [submitting, setSubmitting] = useState(false);
   const [uploading, setUploading] = useState(false);
+  // Desglose del precio sugerido devuelto por el endpoint del back.
+  const [breakdown, setBreakdown] = useState(null);
+  const [calculando, setCalculando] = useState(false);
 
   const editando = form._id != null;
   const destacadosCount = postres.filter((p) => p.destacado && p.activo).length;
@@ -98,7 +104,21 @@ export default function DashboardPostres() {
       setLoading(false);
     }
   }
-  useEffect(() => { cargar(); }, []);
+
+  /* Cargar las recetas disponibles para el dropdown de receta. */
+  async function cargarRecetas() {
+    try {
+      const r = await fetch(`${API_BASE}/recetas/recetas`);
+      const j = await r.json();
+      // La API puede devolver el array directo o envuelto en { data }.
+      const list = Array.isArray(j) ? j : (j?.data || []);
+      setRecetas(list);
+    } catch (e) {
+      console.error("Error cargando recetas:", e);
+    }
+  }
+
+  useEffect(() => { cargar(); cargarRecetas(); }, []);
 
   /* ── Editar / Nuevo ── */
   const editar = (p) => {
@@ -113,10 +133,49 @@ export default function DashboardPostres() {
       activo: p.activo !== false,
       destacado: !!p.destacado,
       orden: p.orden ?? 0,
+      recetaId: p.recetaId || "",
+      costoEmpaque: p.costoEmpaque ?? "",
     });
+    setBreakdown(null); // limpiar desglose anterior al cargar otro postre
     window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
   };
-  const nuevo = () => setForm(FORM_VACIO);
+  const nuevo = () => {
+    setForm(FORM_VACIO);
+    setBreakdown(null);
+  };
+
+  /* Llamar al endpoint que calcula el precio sugerido desde la receta
+     + branding global + empaque ingresado en este form. */
+  const calcularPrecioSugerido = async () => {
+    if (!form.recetaId) {
+      return Swal.fire({ icon: "info", title: "Selecciona una receta primero", background: "#fff1f2", color: "#540027" });
+    }
+    setCalculando(true);
+    try {
+      const r = await fetch(`${API_BASE}/postres/calcular-precio`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${userToken}` },
+        body: JSON.stringify({
+          recetaId: form.recetaId,
+          costoEmpaque: parseFloat(form.costoEmpaque || 0),
+        }),
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j?.message || `HTTP ${r.status}`);
+      setBreakdown(j.data);
+    } catch (err) {
+      console.error(err);
+      Swal.fire({ icon: "error", title: "No se pudo calcular", text: String(err.message || err), background: "#fff1f2", color: "#540027" });
+    } finally {
+      setCalculando(false);
+    }
+  };
+
+  /* Copiar el precio sugerido al campo `precio` del form. */
+  const usarPrecioSugerido = () => {
+    if (!breakdown?.precioSugerido) return;
+    setForm((p) => ({ ...p, precio: String(breakdown.precioSugerido) }));
+  };
 
   /* ── Auto-slug al cambiar nombre (solo si estamos creando) ── */
   const onNombreChange = (e) => {
@@ -156,6 +215,8 @@ export default function DashboardPostres() {
         activo: form.activo,
         destacado: form.destacado,
         orden: Number(form.orden) || 0,
+        recetaId: form.recetaId || null,
+        costoEmpaque: parseFloat(form.costoEmpaque || 0),
       };
       const r = await fetch(url, {
         method,
@@ -166,6 +227,7 @@ export default function DashboardPostres() {
       if (!r.ok) throw new Error(j?.message || `HTTP ${r.status}`);
       await cargar();
       setForm(FORM_VACIO);
+      setBreakdown(null);
       Swal.fire({ icon: "success", title: editando ? "Postre actualizado" : "Postre creado", timer: 1500, showConfirmButton: false, background: "#fff1f2", color: "#540027" });
     } catch (err) {
       console.error(err);
@@ -402,6 +464,78 @@ export default function DashboardPostres() {
                   rows={3}
                   placeholder="Masa de mantequilla rellena de crema de pistache…"
                 />
+              </div>
+
+              {/* ── Cálculo de precio sugerido desde receta ─────────── */}
+              <div className="p-4 rounded-xl border border-secondary" style={{ background: "#fff1f2" }}>
+                <h3 className={`text-xl mb-2 ${sofia.className}`} style={{ color: "var(--burdeos)" }}>
+                  Calcular precio sugerido
+                </h3>
+                <p className="text-xs text-gray-600 mb-3">
+                  Selecciona una receta (toma su costo por porción) e ingresa el empaque que usa este postre. El branding global se suma automáticamente desde Gastos fijos.
+                </p>
+                <div className="grid md:grid-cols-3 gap-4 items-end">
+                  <div>
+                    <label className="block mb-1 text-sm font-medium">Receta</label>
+                    <select
+                      value={form.recetaId}
+                      onChange={(e) => setForm((p) => ({ ...p, recetaId: e.target.value }))}
+                      className={inputStyle}
+                    >
+                      <option value="">— Sin receta —</option>
+                      {recetas.map((r) => (
+                        <option key={r._id} value={r._id}>
+                          {r.nombre_receta} ({r.portions} porciones, ${Number(r.total_cost).toFixed(2)})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block mb-1 text-sm font-medium">Costo de empaque (MXN)</label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={form.costoEmpaque}
+                      onChange={(e) => setForm((p) => ({ ...p, costoEmpaque: e.target.value }))}
+                      className={inputStyle}
+                      placeholder="ej. 15 (domo, caja, etc.)"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={calcularPrecioSugerido}
+                    disabled={!form.recetaId || calculando}
+                    className="px-4 py-2.5 rounded-full text-white font-bold disabled:opacity-50"
+                    style={{ background: "var(--burdeos)" }}
+                  >
+                    {calculando ? "Calculando…" : "Calcular precio sugerido"}
+                  </button>
+                </div>
+
+                {breakdown && (
+                  <div className="mt-4 bg-white rounded-lg p-4 border border-secondary">
+                    <table className="w-full text-sm">
+                      <tbody>
+                        <tr><td className="py-1">Receta: <strong>{breakdown.receta.nombre_receta}</strong></td><td></td></tr>
+                        <tr><td className="py-1 pl-4">Costo por porción ({breakdown.receta.portions} porciones, total ${breakdown.receta.total_cost.toFixed(2)})</td><td className="py-1 text-right">${breakdown.costoMateriaPrima.toFixed(2)}</td></tr>
+                        <tr><td className="py-1">+ Branding (global)</td><td className="py-1 text-right">${breakdown.costoBranding.toFixed(2)}</td></tr>
+                        <tr><td className="py-1">+ Empaque (este postre)</td><td className="py-1 text-right">${breakdown.costoEmpaque.toFixed(2)}</td></tr>
+                        <tr className="border-t border-secondary"><td className="py-2 font-bold">Costo total</td><td className="py-2 text-right font-bold">${breakdown.costoTotal.toFixed(2)}</td></tr>
+                        <tr><td className="py-1 text-gray-600">+ Markup ({breakdown.markupPct}%)</td><td className="py-1 text-right text-gray-600">${(breakdown.precioSugerido - breakdown.costoTotal).toFixed(2)}</td></tr>
+                        <tr className="border-t border-secondary"><td className="py-2 font-bold" style={{ color: "var(--burdeos)" }}>Precio sugerido</td><td className="py-2 text-right font-bold text-xl" style={{ color: "var(--burdeos)" }}>${breakdown.precioSugerido.toFixed(2)}</td></tr>
+                      </tbody>
+                    </table>
+                    <button
+                      type="button"
+                      onClick={usarPrecioSugerido}
+                      className="mt-3 px-4 py-2 rounded-full text-sm font-bold border border-secondary hover:bg-rosa-4"
+                      style={{ color: "var(--burdeos)" }}
+                    >
+                      Usar como precio del postre →
+                    </button>
+                  </div>
+                )}
               </div>
 
               <div className="grid md:grid-cols-3 gap-4">


### PR DESCRIPTION
Acompaña [BackPastelero#78](https://github.com/mipasteleria/BackPastelero/pull/78).

## Settings (`/dashboard/gastosfijosymanodeobra`)
Nueva sección **🎂 Configuración de Postres**:
- **Costo de branding por postre** (global, MXN).
- **Markup sugerido** (%, default 60).

El empaque NO va aquí — varía por postre y se ingresa en cada postre.

## Admin de postres (`/dashboard/postres`)
Nuevo bloque **Calcular precio sugerido** en el form:
- **Dropdown de receta** (muestra nombre + porciones + total_cost).
- **Costo de empaque** input por postre (domo, caja, etc.).
- Botón **Calcular precio sugerido** → llama `POST /postres/calcular-precio`.
- Tabla con el desglose:

  | | |
  |---|---:|
  | Receta: Nombre | |
  | Costo por porción (N porciones) | $X |
  | + Branding (global) | $X |
  | + Empaque (este postre) | $X |
  | **Costo total** | **$X** |
  | + Markup (N%) | $X |
  | **Precio sugerido** | **$X** |

- Botón **Usar como precio del postre →** copia el sugerido al campo precio.
- `recetaId` y `costoEmpaque` persisten en el postre.

## Test plan
- [ ] En settings, configurar costoBrandingPorPostre = $5 y markupPostresPct = 60. Guardar.
- [ ] Crear un postre, seleccionar una receta de $200 / 4 porciones, empaque $15 → debe sugerir (50 + 5 + 15) × 1.6 = $112.
- [ ] Botón "Usar como precio" rellena el campo Precio con 112.
- [ ] Guardar el postre → recetaId y costoEmpaque se persisten.
- [ ] Editar el postre → los valores se cargan; al recalcular dan el mismo resultado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)