### PR TITLE
feat(dashboard): nav mobile — todas las opciones + slot 'Más'

### DIFF
--- a/front-pastelero/pages/dashboard/index.jsx
+++ b/front-pastelero/pages/dashboard/index.jsx
@@ -70,6 +70,46 @@ const NAV_CARDS = [
     ),
   },
   {
+    href: "/dashboard/galletas-ny",
+    label: "Galletas NY",
+    description: "Catálogo de sabores y stock por pieza",
+    accent: "var(--burdeos)",
+    blob: "rgba(84,0,39,0.10)",
+    icon: (
+      <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <circle cx="9" cy="10" r="1" />
+        <circle cx="14" cy="9" r="1" />
+        <circle cx="15" cy="14" r="1" />
+        <circle cx="10" cy="15" r="1" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dashboard/postres",
+    label: "Postres",
+    description: "Catálogo Top Postres con receta + empaque",
+    accent: "var(--rosa)",
+    blob: "rgba(255,111,125,0.15)",
+    icon: (
+      <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 19h18M5 19V12a7 7 0 0 1 14 0v7M9 7V4M12 7V3M15 7V4" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dashboard/pedidos-galletas",
+    label: "Pedidos Galletas NY",
+    description: "Órdenes confirmadas y en preparación",
+    accent: "var(--menta-deep)",
+    blob: "rgba(111,201,168,0.18)",
+    icon: (
+      <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2m-6 9 2 2 4-4" />
+      </svg>
+    ),
+  },
+  {
     href: "/dashboard/productos",
     label: "Productos del Home",
     description: "Gestiona los productos visibles en tu tienda",
@@ -78,6 +118,30 @@ const NAV_CARDS = [
     icon: (
       <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
         <path d="M3 6h18M3 12h18M3 18h18" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dashboard/home-config",
+    label: "Home (hero)",
+    description: "Imagen del hero, chips y destinos",
+    accent: "var(--lavanda)",
+    blob: "rgba(217,196,232,0.25)",
+    icon: (
+      <svg width="28" height="28" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M10 2 1 9h2v8h5v-5h4v5h5V9h2L10 2Z" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dashboard/resenas",
+    label: "Reseñas",
+    description: "Modera reseñas verificadas por compra",
+    accent: "#E8B43A",
+    blob: "rgba(232,180,58,0.18)",
+    icon: (
+      <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27Z" />
       </svg>
     ),
   },

--- a/front-pastelero/src/components/footeradmin.jsx
+++ b/front-pastelero/src/components/footeradmin.jsx
@@ -40,12 +40,20 @@ const NAV_ITEMS = [
       </svg>
     ),
   },
+  // Slot "Más": atajo al home del dashboard donde están TODAS las
+  // opciones como cards. No alargamos el bottom tab a 10+ items —
+  // 5 es el límite cómodo de espacio. Si en el futuro hay opciones
+  // muy usadas que pasan a primer plano, se cambian los 4 anteriores.
   {
-    href: "/dashboard/usuarios",
-    label: "Usuarios",
+    href: "/dashboard",
+    exact: true,
+    isMore: true,
+    label: "Más",
     icon: (
-      <svg width="22" height="22" fill="currentColor" viewBox="0 0 20 18">
-        <path d="M14 2a3.963 3.963 0 0 0-1.4.267 6.439 6.439 0 0 1-1.331 6.638A4 4 0 1 0 14 2Zm1 9h-1.264A6.957 6.957 0 0 1 15 15v2a2.97 2.97 0 0 1-.184 1H19a1 1 0 0 0 1-1v-1a5.006 5.006 0 0 0-5-5ZM6.5 9a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9ZM8 10H5a5.006 5.006 0 0 0-5 5v2a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-2a5.006 5.006 0 0 0-5-5Z" />
+      <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="5" cy="12" r="1.5" />
+        <circle cx="12" cy="12" r="1.5" />
+        <circle cx="19" cy="12" r="1.5" />
       </svg>
     ),
   },


### PR DESCRIPTION
En mobile el admin solo veía 7 cards en el home del dashboard y 5 items en el bottom tab. Faltaban Postres, Galletas NY admin, Pedidos galletas, Home config, Reseñas.

## Cambios
- **Dashboard home**: NAV_CARDS extendido a 12 cards (refleja TODO el aside admin).
- **Bottom tab**: "Usuarios" → "Más" → `/dashboard`. Acceso a todas las opciones desde mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)