### PR TITLE
feat(cotizacion-catalogos): Fase B admin — 4 CRUD + hub + aside

### DIFF
--- a/front-pastelero/pages/dashboard/cotizacion-catalogos/coberturas.jsx
+++ b/front-pastelero/pages/dashboard/cotizacion-catalogos/coberturas.jsx
@@ -1,0 +1,66 @@
+import CatalogoCrudPage from "@/src/components/cotizacionCatalogos/CatalogoCrudPage";
+
+const DEFAULT = {
+  slug: "",
+  nombre: "",
+  descripcion: "",
+  costoPorPorcion: 0,
+  esFondant: false,
+  activo: true,
+  orden: 0,
+};
+
+export default function CoberturasPage() {
+  return (
+    <CatalogoCrudPage
+      tipo="coberturas"
+      labelSingular="Cobertura"
+      labelPlural="Coberturas"
+      defaultDoc={DEFAULT}
+      columnas={[
+        {
+          key: "costoPorPorcion",
+          label: "Costo / porción",
+          render: (d) => `$${Number(d.costoPorPorcion ?? 0).toFixed(2)}`,
+        },
+        {
+          key: "esFondant",
+          label: "Fondant",
+          render: (d) => d.esFondant
+            ? <span className="text-xs font-semibold px-2 py-0.5 rounded bg-amber-100 text-amber-700">Sí</span>
+            : <span className="text-xs text-gray-400">—</span>,
+        },
+      ]}
+      renderFormFields={({ form, setForm }) => (
+        <>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">
+              Costo extra / porción
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              className="border rounded px-3 py-2 w-full"
+              value={form.costoPorPorcion ?? 0}
+              onChange={(e) => setForm({ ...form, costoPorPorcion: Number(e.target.value) })}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">¿Es fondant?</label>
+            <label className="flex items-center gap-2 mt-2">
+              <input
+                type="checkbox"
+                checked={!!form.esFondant}
+                onChange={(e) => setForm({ ...form, esFondant: e.target.checked })}
+              />
+              <span className="text-sm">
+                {form.esFondant ? "Sí — muestra toggle especial en /cotizacion" : "No"}
+              </span>
+            </label>
+          </div>
+        </>
+      )}
+    />
+  );
+}

--- a/front-pastelero/pages/dashboard/cotizacion-catalogos/decoraciones.jsx
+++ b/front-pastelero/pages/dashboard/cotizacion-catalogos/decoraciones.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import CatalogoCrudPage from "@/src/components/cotizacionCatalogos/CatalogoCrudPage";
+import { useAuth } from "@/src/context";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const DEFAULT = {
+  slug: "",
+  nombre: "",
+  descripcion: "",
+  emoji: "🎀",
+  tecnicaCreativaId: "",
+  costoManual: 0,
+  activo: true,
+  orden: 0,
+};
+
+export default function DecoracionesPage() {
+  const { userToken } = useAuth();
+  const [tecnicas, setTecnicas] = useState([]);
+
+  useEffect(() => {
+    if (!userToken) return;
+    // ?todas=true para incluir las inactivas — el admin debe ver todas
+    // al asignar técnica creativa.
+    fetch(`${API_BASE}/tecnicas?todas=true`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    })
+      .then((r) => r.json())
+      .then((j) => setTecnicas(j.data || []))
+      .catch(console.error);
+  }, [userToken]);
+
+  return (
+    <CatalogoCrudPage
+      tipo="decoraciones"
+      labelSingular="Decoración"
+      labelPlural="Decoraciones"
+      defaultDoc={DEFAULT}
+      renderRowExtra={(d) => (
+        <span style={{ fontSize: "1.4rem" }}>{d.emoji || "🎀"}</span>
+      )}
+      columnas={[
+        {
+          key: "tecnica",
+          label: "Técnica creativa",
+          render: (d) => {
+            const idStr = d.tecnicaCreativaId?._id || d.tecnicaCreativaId;
+            const t = tecnicas.find((x) => String(x._id) === String(idStr));
+            return t ? t.nombre : <span className="text-gray-400 italic">manual</span>;
+          },
+        },
+        {
+          key: "costo",
+          label: "Costo",
+          render: (d) => (
+            d.tecnicaCreativaId
+              ? <span className="text-xs text-gray-500">Calculado en Fase D</span>
+              : `$${Number(d.costoManual ?? 0).toFixed(2)}`
+          ),
+        },
+      ]}
+      renderFormFields={({ form, setForm }) => (
+        <>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">Emoji</label>
+            <input
+              className="border rounded px-3 py-2 w-full"
+              value={form.emoji || ""}
+              onChange={(e) => setForm({ ...form, emoji: e.target.value })}
+              placeholder="🎀"
+              maxLength={4}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">
+              Técnica creativa vinculada (opcional)
+            </label>
+            <select
+              className="border rounded px-3 py-2 w-full"
+              value={form.tecnicaCreativaId || ""}
+              onChange={(e) => setForm({ ...form, tecnicaCreativaId: e.target.value || null })}
+            >
+              <option value="">— Sin técnica (costo manual) —</option>
+              {tecnicas.map((t) => (
+                <option key={t._id} value={t._id}>
+                  {t.nombre} ({t.categoria})
+                </option>
+              ))}
+            </select>
+            <div className="text-[10px] text-gray-400 mt-1">
+              Si eliges técnica, el costo escala con porciones automáticamente en Fase D.
+            </div>
+          </div>
+          <div className="md:col-span-2">
+            <label className="block text-xs font-semibold mb-1 text-gray-600">
+              Costo manual (si no hay técnica)
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              className="border rounded px-3 py-2 w-full"
+              value={form.costoManual ?? 0}
+              onChange={(e) => setForm({ ...form, costoManual: Number(e.target.value) })}
+              disabled={!!form.tecnicaCreativaId}
+            />
+            <div className="text-[10px] text-gray-400 mt-1">
+              Costo plano sumado al total. No escala con porciones.
+            </div>
+          </div>
+        </>
+      )}
+    />
+  );
+}

--- a/front-pastelero/pages/dashboard/cotizacion-catalogos/index.jsx
+++ b/front-pastelero/pages/dashboard/cotizacion-catalogos/index.jsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import NavbarAdmin from "@/src/components/navbar";
+import Asideadmin from "@/src/components/asideadmin";
+import FooterDashboard from "@/src/components/footeradmin";
+import { Poppins as PoppinsFont, Sofia as SofiaFont } from "next/font/google";
+
+const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
+const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
+
+// Hub mini de los 4 catálogos. El cliente final usa /cotizacion.
+// El aside también tiene los 4 enlaces sueltos — esta página es un atajo
+// visual desde el dashboard.
+const CARDS = [
+  {
+    href: "/dashboard/cotizacion-catalogos/sabores",
+    label: "Sabores del bizcocho",
+    desc: "Catálogo con vínculo opcional a Recetas",
+    accent: "var(--mantequilla)",
+    blob: "rgba(255,233,155,0.25)",
+  },
+  {
+    href: "/dashboard/cotizacion-catalogos/rellenos",
+    label: "Rellenos",
+    desc: "Costo manual por porción",
+    accent: "var(--rosa)",
+    blob: "rgba(255,111,125,0.15)",
+  },
+  {
+    href: "/dashboard/cotizacion-catalogos/coberturas",
+    label: "Coberturas",
+    desc: "Buttercream / ganache / fondant",
+    accent: "var(--lavanda)",
+    blob: "rgba(217,196,232,0.3)",
+  },
+  {
+    href: "/dashboard/cotizacion-catalogos/decoraciones",
+    label: "Decoraciones",
+    desc: "Vinculadas a Técnicas Creativas",
+    accent: "var(--menta-deep)",
+    blob: "rgba(111,201,168,0.15)",
+  },
+];
+
+export default function CotizacionCatalogosHub() {
+  return (
+    <div className={poppins.className} style={{ background: "var(--bg-sunken)", minHeight: "100vh" }}>
+      <NavbarAdmin />
+      <div className="flex flex-row mt-16">
+        <Asideadmin />
+        <main className="flex-grow min-w-0 px-5 py-7 pb-20 md:pb-8 max-w-screen-xl">
+          <h1
+            className={sofia.className}
+            style={{ fontSize: "2.25rem", color: "var(--burdeos)", lineHeight: 1.1 }}
+          >
+            Catálogos de cotización
+          </h1>
+          <p style={{ color: "var(--text-muted)", fontSize: "0.9rem", marginTop: 4 }}>
+            Opciones que el cliente ve en <code className="px-1 bg-gray-100 rounded">/cotizacion</code>.
+          </p>
+
+          <div
+            className="mt-6"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+              gap: "1.25rem",
+            }}
+          >
+            {CARDS.map((card) => (
+              <Link key={card.href} href={card.href} style={{ textDecoration: "none" }}>
+                <div
+                  style={{
+                    background: "var(--bg-raised)",
+                    borderRadius: "var(--r-xl)",
+                    padding: "1.5rem",
+                    boxShadow: "var(--shadow-sm)",
+                    border: "1px solid var(--border-color)",
+                    position: "relative",
+                    overflow: "hidden",
+                    cursor: "pointer",
+                    transition: "all 200ms",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.boxShadow = "var(--shadow-md)";
+                    e.currentTarget.style.transform = "translateY(-2px)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.boxShadow = "var(--shadow-sm)";
+                    e.currentTarget.style.transform = "translateY(0)";
+                  }}
+                >
+                  <div
+                    aria-hidden="true"
+                    style={{
+                      position: "absolute",
+                      top: -30, right: -30,
+                      width: 110, height: 110,
+                      borderRadius: "50%",
+                      background: card.blob,
+                    }}
+                  />
+                  <div style={{ fontWeight: 800, fontSize: "1.05rem", color: "var(--color-text)", marginBottom: 4 }}>
+                    {card.label}
+                  </div>
+                  <div style={{ fontSize: "0.8rem", color: "var(--text-muted)", lineHeight: 1.5 }}>
+                    {card.desc}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </main>
+      </div>
+      <FooterDashboard />
+    </div>
+  );
+}

--- a/front-pastelero/pages/dashboard/cotizacion-catalogos/rellenos.jsx
+++ b/front-pastelero/pages/dashboard/cotizacion-catalogos/rellenos.jsx
@@ -1,0 +1,46 @@
+import CatalogoCrudPage from "@/src/components/cotizacionCatalogos/CatalogoCrudPage";
+
+const DEFAULT = {
+  slug: "",
+  nombre: "",
+  descripcion: "",
+  costoPorPorcion: 0,
+  activo: true,
+  orden: 0,
+};
+
+export default function RellenosPage() {
+  return (
+    <CatalogoCrudPage
+      tipo="rellenos"
+      labelSingular="Relleno"
+      labelPlural="Rellenos"
+      defaultDoc={DEFAULT}
+      columnas={[
+        {
+          key: "costoPorPorcion",
+          label: "Costo / porción",
+          render: (d) => `$${Number(d.costoPorPorcion ?? 0).toFixed(2)}`,
+        },
+      ]}
+      renderFormFields={({ form, setForm }) => (
+        <div>
+          <label className="block text-xs font-semibold mb-1 text-gray-600">
+            Costo extra / porción
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            className="border rounded px-3 py-2 w-full"
+            value={form.costoPorPorcion ?? 0}
+            onChange={(e) => setForm({ ...form, costoPorPorcion: Number(e.target.value) })}
+          />
+          <div className="text-[10px] text-gray-400 mt-1">
+            Se suma al costo total del pastel para Fase D del costeo.
+          </div>
+        </div>
+      )}
+    />
+  );
+}

--- a/front-pastelero/pages/dashboard/cotizacion-catalogos/sabores.jsx
+++ b/front-pastelero/pages/dashboard/cotizacion-catalogos/sabores.jsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import Swal from "sweetalert2";
+import CatalogoCrudPage from "@/src/components/cotizacionCatalogos/CatalogoCrudPage";
+import { useAuth } from "@/src/context";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const DEFAULT = {
+  slug: "",
+  nombre: "",
+  descripcion: "",
+  swatch: "linear-gradient(135deg,#FFE2E7,#FFC3C9)",
+  emoji: "",
+  recetaId: "",
+  costoManualPorPorcion: 0,
+  activo: true,
+  orden: 0,
+};
+
+export default function SaboresPage() {
+  const { userToken } = useAuth();
+  const [recetas, setRecetas] = useState([]);
+
+  // Cargar recetas para el selector — solo una vez.
+  useEffect(() => {
+    if (!userToken) return;
+    fetch(`${API_BASE}/recetas/recetas`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    })
+      .then((r) => r.json())
+      .then((j) => setRecetas(j.data || j || []))
+      .catch(console.error);
+  }, [userToken]);
+
+  // Recosteo manual desde la receta vinculada — pide el costo unitario al back.
+  const recostear = async (id) => {
+    try {
+      const r = await fetch(`${API_BASE}/cotizacion-catalogos/sabores/${id}/recostear`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${userToken}` },
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.message || "Error");
+      Swal.fire({
+        icon: "success",
+        title: `Recosteado: $${j.data?.costoUnitarioSnapshot?.toFixed(2) ?? "?"} / porción`,
+        timer: 2200,
+        showConfirmButton: false,
+        background: "#fff1f2",
+        color: "#540027",
+      });
+      // Trigger reload — el componente padre maneja el fetch; un truco
+      // simple es recargar la página. TODO: pasar callback de refresh.
+      window.location.reload();
+    } catch (e) {
+      Swal.fire({ icon: "error", title: e.message, timer: 2200, showConfirmButton: false });
+    }
+  };
+
+  return (
+    <CatalogoCrudPage
+      tipo="sabores"
+      labelSingular="Sabor"
+      labelPlural="Sabores del bizcocho"
+      defaultDoc={DEFAULT}
+      renderRowExtra={(d) => (
+        <div
+          aria-hidden="true"
+          style={{
+            width: 28, height: 28, borderRadius: "50%",
+            background: d.swatch || "var(--rosa-3)",
+            flexShrink: 0,
+            border: "1px solid #eee",
+          }}
+        />
+      )}
+      columnas={[
+        {
+          key: "receta",
+          label: "Receta",
+          render: (d) => {
+            const r = recetas.find((x) => String(x._id) === String(d.recetaId?._id || d.recetaId));
+            return r ? r.nombre_receta : <span className="text-gray-400 italic">manual</span>;
+          },
+        },
+        {
+          key: "costo",
+          label: "Costo / porción",
+          render: (d) => {
+            const c = d.costoUnitarioSnapshot ?? d.costoManualPorPorcion ?? 0;
+            return `$${Number(c).toFixed(2)}`;
+          },
+        },
+        {
+          key: "recostear",
+          label: "Recosteo",
+          render: (d) => (
+            d.recetaId ? (
+              <button
+                onClick={() => recostear(d._id)}
+                className="text-xs text-accent hover:underline"
+              >
+                Recostear
+              </button>
+            ) : <span className="text-xs text-gray-300">—</span>
+          ),
+        },
+      ]}
+      renderFormFields={({ form, setForm }) => (
+        <>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">Emoji opcional</label>
+            <input
+              className="border rounded px-3 py-2 w-full"
+              value={form.emoji || ""}
+              onChange={(e) => setForm({ ...form, emoji: e.target.value })}
+              placeholder="🍰"
+              maxLength={4}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">Swatch (CSS background)</label>
+            <input
+              className="border rounded px-3 py-2 w-full font-mono text-xs"
+              value={form.swatch || ""}
+              onChange={(e) => setForm({ ...form, swatch: e.target.value })}
+            />
+            <div className="mt-1 h-6 rounded" style={{ background: form.swatch }} />
+          </div>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">Receta vinculada (opcional)</label>
+            <select
+              className="border rounded px-3 py-2 w-full"
+              value={form.recetaId || ""}
+              onChange={(e) => setForm({ ...form, recetaId: e.target.value || null })}
+            >
+              <option value="">— Sin receta (costo manual) —</option>
+              {recetas.map((r) => (
+                <option key={r._id} value={r._id}>{r.nombre_receta}</option>
+              ))}
+            </select>
+            <div className="text-[10px] text-gray-400 mt-1">
+              Si eliges receta, el botón "Recostear" en la tabla congela el costo unitario.
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs font-semibold mb-1 text-gray-600">
+              Costo manual / porción (fallback)
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              className="border rounded px-3 py-2 w-full"
+              value={form.costoManualPorPorcion ?? 0}
+              onChange={(e) => setForm({ ...form, costoManualPorPorcion: Number(e.target.value) })}
+            />
+            <div className="text-[10px] text-gray-400 mt-1">
+              Solo se usa si no hay receta o si la receta aún no se ha recosteado.
+            </div>
+          </div>
+        </>
+      )}
+    />
+  );
+}

--- a/front-pastelero/pages/dashboard/index.jsx
+++ b/front-pastelero/pages/dashboard/index.jsx
@@ -22,6 +22,18 @@ const NAV_CARDS = [
     ),
   },
   {
+    href: "/dashboard/cotizacion-catalogos",
+    label: "Catálogos de cotización",
+    description: "Sabores, rellenos, coberturas y decoraciones",
+    accent: "var(--burdeos)",
+    blob: "rgba(84,0,39,0.10)",
+    icon: (
+      <svg width="28" height="28" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2 9 9l-7 .5 5.5 4.5L5.5 22 12 18l6.5 4-2-8 5.5-4.5L15 9l-3-7Z" />
+      </svg>
+    ),
+  },
+  {
     href: "/dashboard/insumosytrabajomanual",
     label: "Insumos y Trabajo Manual",
     description: "Administra materias primas y tarifas de trabajo",

--- a/front-pastelero/src/components/asideadmin.jsx
+++ b/front-pastelero/src/components/asideadmin.jsx
@@ -104,6 +104,47 @@ const NAV_GROUPS = [
     ],
   },
   {
+    label: "Cotización Pastel",
+    items: [
+      {
+        href: "/dashboard/cotizacion-catalogos/sabores",
+        label: "Sabores del bizcocho",
+        icon: (
+          <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 19h18M5 19V12a7 7 0 0 1 14 0v7M9 7V4M12 7V3M15 7V4" />
+          </svg>
+        ),
+      },
+      {
+        href: "/dashboard/cotizacion-catalogos/rellenos",
+        label: "Rellenos",
+        icon: (
+          <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 10h16M4 14h16M6 18h12" />
+          </svg>
+        ),
+      },
+      {
+        href: "/dashboard/cotizacion-catalogos/coberturas",
+        label: "Coberturas",
+        icon: (
+          <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 8c4-4 14-4 18 0M3 8v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8" />
+          </svg>
+        ),
+      },
+      {
+        href: "/dashboard/cotizacion-catalogos/decoraciones",
+        label: "Decoraciones",
+        icon: (
+          <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 2 9 9l-7 .5 5.5 4.5L5.5 22 12 18l6.5 4-2-8 5.5-4.5L15 9l-3-7Z" />
+          </svg>
+        ),
+      },
+    ],
+  },
+  {
     label: "Pedidos",
     items: [
       {

--- a/front-pastelero/src/components/cotizacionCatalogos/CatalogoCrudPage.jsx
+++ b/front-pastelero/src/components/cotizacionCatalogos/CatalogoCrudPage.jsx
@@ -1,0 +1,320 @@
+import { useEffect, useState, useMemo } from "react";
+import Swal from "sweetalert2";
+import NavbarAdmin from "@/src/components/navbar";
+import Asideadmin from "@/src/components/asideadmin";
+import FooterDashboard from "@/src/components/footeradmin";
+import { Poppins as PoppinsFont, Sofia as SofiaFont } from "next/font/google";
+import { useAuth } from "@/src/context";
+
+const poppins = PoppinsFont({ subsets: ["latin"], weight: ["400", "700"] });
+const sofia = SofiaFont({ subsets: ["latin"], weight: ["400"] });
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+/**
+ * CatalogoCrudPage — pantalla CRUD genérica para los 4 catálogos de
+ * cotización (sabor / relleno / cobertura / decoración).
+ *
+ * Cada catálogo invocador pasa:
+ *  - `tipo`              "sabores" | "rellenos" | "coberturas" | "decoraciones"
+ *  - `label`             singular ("Sabor") y plural ("Sabores") para titulos
+ *  - `columnas`          definición de columnas de tabla
+ *  - `defaultDoc`        valores por defecto al crear
+ *  - `renderFormFields`  función que recibe ({ form, setForm }) y devuelve los
+ *                        inputs específicos del catálogo (ej. selector de receta
+ *                        para sabores, selector de técnica para decoraciones).
+ *
+ * Comportamiento común:
+ *  - Carga ?incluyeInactivos=true para que el admin vea todo (también
+ *    los activo:false).
+ *  - Crear / editar inline en el mismo formulario; "editar" pre-llena.
+ *  - Toggle activo con PUT { activo }.
+ *  - Eliminar con confirm Swal.
+ */
+export default function CatalogoCrudPage({
+  tipo,
+  labelSingular,
+  labelPlural,
+  columnas,
+  defaultDoc,
+  renderFormFields,
+  // Opcional: render extra a la derecha del nombre en cada fila (ej. swatch).
+  renderRowExtra,
+  // Hook opcional para post-procesar la lista (ej. ordenar visualmente).
+  postProcesarLista,
+}) {
+  const { userToken } = useAuth();
+  const authHeader = userToken ? { Authorization: `Bearer ${userToken}` } : {};
+
+  const [docs, setDocs] = useState([]);
+  const [form, setForm] = useState(defaultDoc);
+  const [editingId, setEditingId] = useState(null);
+  const [cargando, setCargando] = useState(false);
+
+  const url = `${API_BASE}/cotizacion-catalogos/${tipo}`;
+
+  // ── Cargar ───────────────────────────────────────────────────────
+  const recargar = async () => {
+    try {
+      const r = await fetch(`${url}?incluyeInactivos=true`, { headers: authHeader });
+      const j = await r.json();
+      let list = j.data ?? [];
+      if (postProcesarLista) list = postProcesarLista(list);
+      setDocs(list);
+    } catch (e) {
+      console.error("Error cargando catálogo:", e);
+    }
+  };
+  useEffect(() => { recargar(); /* eslint-disable-line */ }, [userToken]);
+
+  // ── Submit (crear/editar) ────────────────────────────────────────
+  const submit = async (e) => {
+    e?.preventDefault();
+    setCargando(true);
+    try {
+      const method = editingId ? "PUT" : "POST";
+      const endpoint = editingId ? `${url}/${editingId}` : url;
+      const r = await fetch(endpoint, {
+        method,
+        headers: { "Content-Type": "application/json", ...authHeader },
+        body: JSON.stringify(form),
+      });
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.message || "Error");
+
+      await recargar();
+      setForm(defaultDoc);
+      setEditingId(null);
+      Swal.fire({
+        icon: "success",
+        title: editingId ? `${labelSingular} actualizado` : `${labelSingular} creado`,
+        timer: 1600,
+        showConfirmButton: false,
+        background: "#fff1f2",
+        color: "#540027",
+      });
+    } catch (e) {
+      Swal.fire({ icon: "error", title: e.message, timer: 2200, showConfirmButton: false });
+    } finally {
+      setCargando(false);
+    }
+  };
+
+  const editar = (doc) => {
+    setEditingId(doc._id);
+    setForm({ ...defaultDoc, ...doc });
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const cancelarEdicion = () => {
+    setEditingId(null);
+    setForm(defaultDoc);
+  };
+
+  const toggleActivo = async (doc) => {
+    try {
+      const r = await fetch(`${url}/${doc._id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", ...authHeader },
+        body: JSON.stringify({ activo: !doc.activo }),
+      });
+      if (!r.ok) throw new Error();
+      await recargar();
+    } catch {
+      Swal.fire({ icon: "error", title: "Error al actualizar", timer: 1800, showConfirmButton: false });
+    }
+  };
+
+  const eliminar = async (doc) => {
+    const result = await Swal.fire({
+      title: "¿Eliminar?",
+      text: `Se eliminará "${doc.nombre}" del catálogo.`,
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#FF6F7D",
+      cancelButtonColor: "#D6A7BC",
+      confirmButtonText: "Sí, eliminar",
+      cancelButtonText: "Cancelar",
+    });
+    if (!result.isConfirmed) return;
+
+    try {
+      const r = await fetch(`${url}/${doc._id}`, { method: "DELETE", headers: authHeader });
+      if (!r.ok) throw new Error();
+      await recargar();
+      Swal.fire({ icon: "success", title: "Eliminado", timer: 1600, showConfirmButton: false, background: "#fff1f2", color: "#540027" });
+    } catch {
+      Swal.fire({ icon: "error", title: "Error al eliminar", timer: 1800, showConfirmButton: false });
+    }
+  };
+
+  return (
+    <div className={`text-text ${poppins.className}`}>
+      <NavbarAdmin className="fixed top-0 w-full z-50" />
+      <div className="flex flex-row mt-16">
+        <Asideadmin />
+        <main className="flex-grow w-full max-w-screen-xl mx-auto px-4 md:px-8 pb-24 md:pb-8">
+          <h1 className={`text-4xl py-4 ${sofia.className}`}>{labelPlural}</h1>
+          <p className="text-sm text-gray-500 -mt-2 mb-4">
+            Catálogo de {labelPlural.toLowerCase()} para la cotización personalizada.
+            El cliente lo ve en <code className="px-1 bg-gray-100 rounded">/cotizacion</code>.
+          </p>
+
+          {/* ── Form ───────────────────────────────────────────── */}
+          <form
+            onSubmit={submit}
+            className="shadow-md rounded-lg p-4 md:p-6 mb-6"
+            style={{ background: "#fff", border: "1px solid var(--border-color)" }}
+          >
+            <div className="text-sm font-bold mb-3" style={{ color: "var(--burdeos)" }}>
+              {editingId ? `Editar ${labelSingular.toLowerCase()}` : `Nuevo ${labelSingular.toLowerCase()}`}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <Field label="Nombre">
+                <input
+                  className="border rounded px-3 py-2 w-full"
+                  value={form.nombre || ""}
+                  onChange={(e) => setForm({ ...form, nombre: e.target.value })}
+                  required
+                />
+              </Field>
+              <Field label="Slug (URL-friendly)">
+                <input
+                  className="border rounded px-3 py-2 w-full"
+                  value={form.slug || ""}
+                  onChange={(e) => setForm({ ...form, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-") })}
+                  required
+                  placeholder="vainilla-clasica"
+                  pattern="[a-z0-9-]+"
+                />
+              </Field>
+              <Field label="Descripción" full>
+                <input
+                  className="border rounded px-3 py-2 w-full"
+                  value={form.descripcion || ""}
+                  onChange={(e) => setForm({ ...form, descripcion: e.target.value })}
+                />
+              </Field>
+
+              {renderFormFields({ form, setForm, authHeader })}
+
+              <Field label="Orden">
+                <input
+                  type="number"
+                  className="border rounded px-3 py-2 w-full"
+                  value={form.orden ?? 0}
+                  onChange={(e) => setForm({ ...form, orden: Number(e.target.value) })}
+                />
+              </Field>
+              <Field label="Activo">
+                <label className="flex items-center gap-2 mt-2">
+                  <input
+                    type="checkbox"
+                    checked={!!form.activo}
+                    onChange={(e) => setForm({ ...form, activo: e.target.checked })}
+                  />
+                  <span className="text-sm">{form.activo ? "Sí — visible al cliente" : "No — oculto"}</span>
+                </label>
+              </Field>
+            </div>
+
+            <div className="flex gap-2 mt-4 justify-end">
+              {editingId && (
+                <button
+                  type="button"
+                  onClick={cancelarEdicion}
+                  className="px-4 py-2 rounded text-sm font-semibold text-gray-600 border"
+                >
+                  Cancelar
+                </button>
+              )}
+              <button
+                type="submit"
+                disabled={cargando}
+                className="px-6 py-2 rounded text-sm font-semibold text-white shadow-md disabled:opacity-50"
+                style={{ background: "var(--burdeos)" }}
+              >
+                {cargando ? "Guardando…" : editingId ? "Guardar cambios" : `Crear ${labelSingular.toLowerCase()}`}
+              </button>
+            </div>
+          </form>
+
+          {/* ── Tabla ──────────────────────────────────────────── */}
+          <div className="shadow-md rounded-lg overflow-x-auto" style={{ background: "#fff" }}>
+            <table className="w-full text-sm text-left">
+              <thead className="text-xs uppercase border-b border-secondary">
+                <tr>
+                  <th className="px-4 py-3">Nombre</th>
+                  {columnas.map((c) => (
+                    <th key={c.key} className="px-4 py-3">{c.label}</th>
+                  ))}
+                  <th className="px-4 py-3">Activo</th>
+                  <th className="px-4 py-3">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {docs.length === 0 ? (
+                  <tr>
+                    <td colSpan={3 + columnas.length} className="px-4 py-6 text-center text-gray-400">
+                      Sin {labelPlural.toLowerCase()}. Crea el primero arriba.
+                    </td>
+                  </tr>
+                ) : (
+                  docs.map((d) => (
+                    <tr key={d._id} className="border-b border-secondary">
+                      <td className="px-4 py-3 font-medium">
+                        <div className="flex items-center gap-2">
+                          {renderRowExtra && renderRowExtra(d)}
+                          <div>
+                            <div>{d.nombre}</div>
+                            <div className="text-xs text-gray-400">{d.slug}</div>
+                          </div>
+                        </div>
+                      </td>
+                      {columnas.map((c) => (
+                        <td key={c.key} className="px-4 py-3">
+                          {c.render ? c.render(d) : d[c.key]}
+                        </td>
+                      ))}
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => toggleActivo(d)}
+                          className={`text-xs font-semibold px-2 py-0.5 rounded ${
+                            d.activo ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500"
+                          }`}
+                        >
+                          {d.activo ? "Sí" : "No"}
+                        </button>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex gap-3">
+                          <button onClick={() => editar(d)} className="text-accent hover:underline text-xs">
+                            Editar
+                          </button>
+                          <button onClick={() => eliminar(d)} className="text-red-500 hover:text-red-700 text-xs">
+                            Eliminar
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </main>
+      </div>
+      <FooterDashboard />
+    </div>
+  );
+}
+
+// Pequeño wrapper de label + input para limpiar el JSX del form.
+function Field({ label, children, full }) {
+  return (
+    <div className={full ? "md:col-span-2" : ""}>
+      <label className="block text-xs font-semibold mb-1 text-gray-600">{label}</label>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Segunda fase del rediseño de `/cotizacion`. Solo front-admin.

Requiere PR #84 del back (modelos + endpoints) mergeado para funcionar end-to-end.

### Páginas nuevas
| Ruta | Descripción |
|---|---|
| `/dashboard/cotizacion-catalogos` | Hub con 4 cards |
| `/dashboard/cotizacion-catalogos/sabores` | CRUD sabores con selector de Receta + botón "Recostear" |
| `/dashboard/cotizacion-catalogos/rellenos` | CRUD rellenos (costo manual) |
| `/dashboard/cotizacion-catalogos/coberturas` | CRUD coberturas + flag `esFondant` |
| `/dashboard/cotizacion-catalogos/decoraciones` | CRUD decoraciones con selector de Técnica Creativa |

### Componente compartido
`src/components/cotizacionCatalogos/CatalogoCrudPage.jsx` — el form (crear/editar inline) y la tabla son comunes. Cada página pasa `renderFormFields`, `columnas` y `defaultDoc` para personalizar.

### Navegación
- Aside admin: nuevo grupo "Cotización Pastel" con 4 items.
- Dashboard home: card "Catálogos de cotización" cerca del inicio del bloque Catálogo.

## Test plan
- [ ] Visitar `/dashboard/cotizacion-catalogos` → ver hub con 4 cards.
- [ ] Crear sabor sin receta → costo manual aplica.
- [ ] Vincular receta → botón "Recostear" actualiza snapshot.
- [ ] Crear decoración con técnica creativa → costo se calcula en Fase D (texto "Calculado en Fase D").
- [ ] Marcar cobertura como fondant → badge naranja en tabla.
- [ ] Toggle activo y editar funcionan inline.
- [ ] Mobile: bottom tab "Más" → home → card del catálogo navega.

🤖 Generated with [Claude Code](https://claude.com/claude-code)